### PR TITLE
Remove unnecessary GC.SuppressFinalize

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/XmlObjectCore.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/XmlObjectCore.cs
@@ -40,7 +40,6 @@ namespace U8Xml.Internal
         {
             var data = Interlocked.Exchange(ref Unsafe.AsRef(_rawByteData), default);
             if(data != IntPtr.Zero) {
-                GC.SuppressFinalize(this);
                 AllocationSafety.Remove(_byteLength);
                 Marshal.FreeHGlobal(_rawByteData);
                 Unsafe.AsRef(_rawByteData) = IntPtr.Zero;


### PR DESCRIPTION
Remove unnecessary `GC.SuppressFinalize(object)` calls from `XmlObjectCore.Dispose()` to avoid boxing.
This can reduce GC Alloc by 64 bytes.