### PR TITLE
Fix memory leak in XmlObjectCore->Dispose method

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/XmlObjectCore.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/XmlObjectCore.cs
@@ -41,8 +41,7 @@ namespace U8Xml.Internal
             var data = Interlocked.Exchange(ref Unsafe.AsRef(_rawByteData), default);
             if(data != IntPtr.Zero) {
                 AllocationSafety.Remove(_byteLength);
-                Marshal.FreeHGlobal(_rawByteData);
-                Unsafe.AsRef(_rawByteData) = IntPtr.Zero;
+                Marshal.FreeHGlobal(data);
                 Unsafe.AsRef(_byteLength) = 0;
                 Unsafe.AsRef(_offset) = 0;
                 _nodes.Dispose();


### PR DESCRIPTION
I have found that unmanaged memory is not releasing after Disposing and cleaning-up everything is possible.
The problem is calling FreeHGlobal on the pointer that already is Zero

``` public void Dispose()
  {
      var data = Interlocked.Exchange(ref Unsafe.AsRef(**_rawByteData**), default);
      if(data != IntPtr.Zero) {
          AllocationSafety.Remove(_byteLength);
          Marshal.FreeHGlobal(**_rawByteData**);
          Unsafe.AsRef(_rawByteData) = IntPtr.Zero;
          Unsafe.AsRef(_byteLength) = 0;
          Unsafe.AsRef(_offset) = 0;
          _nodes.Dispose();
          _attributes.Dispose();
          _optional.Dispose();
          _entities.Dispose();
      }
  }
```