### PR TITLE
[WIP] Add API

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/AllNodeList.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/AllNodeList.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using U8Xml.Internal;
@@ -14,6 +15,36 @@ namespace U8Xml
         internal AllNodeList(CustomList<XmlNode_> nodes)
         {
             _nodes = nodes;
+        }
+
+        public XmlNode First()
+        {
+            if(Count == 0) { ThrowHelper.ThrowInvalidOperation("Sequence contains no elements."); }
+            return new XmlNode(_nodes.FirstItem);
+        }
+
+        public Option<XmlNode> FirstOrDefault()
+        {
+            return new XmlNode(_nodes.FirstItem);
+        }
+
+        public XmlNode First(Func<XmlNode, bool> predicate)
+        {
+            if(FirstOrDefault(predicate).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation("Sequence contains no matching elements.");
+            }
+            return node;
+        }
+
+        public Option<XmlNode> FirstOrDefault(Func<XmlNode, bool> predicate)
+        {
+            if(predicate is null) { ThrowHelper.ThrowNullArg(nameof(predicate)); }
+            foreach(var node in this) {
+                if(predicate!(node)) {
+                    return node;
+                }
+            }
+            return new Option<XmlNode>(default);
         }
 
         public Enumerator GetEnumerator() => new Enumerator(_nodes.GetEnumerator());

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/EncodingExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/EncodingExtension.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+#if UNITY_2018_1_OR_NEWER
+#define IS_UNITY
+#endif
+
+#if !(NETSTANDARD2_0 || NET48 || IS_UNITY)
+#define ENCODING_SPAN_API
+#endif
+
+
+#if !ENCODING_SPAN_API
+using System;
+using System.Text;
+
+namespace U8Xml.Internal
+{
+    internal static class EncodingExtension
+    {
+        public static unsafe int GetByteCount(this Encoding encoding, ReadOnlySpan<char> span)
+        {
+            fixed(char* ptr = span) {
+                return encoding.GetByteCount(ptr, span.Length);
+            }
+        }
+    }
+}
+#endif  // ENCODING_SPAN_API

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/EncodingExtension.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/EncodingExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b00765bedd1f4f4bbfac6cf73eeb159
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Option.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Option.cs
@@ -7,17 +7,22 @@ using U8Xml.Internal;
 
 namespace U8Xml
 {
+    /// <summary>A type that represents a value that may exist.</summary>
+    /// <typeparam name="T">type of the value</typeparam>
     [DebuggerDisplay("{ToString(),nq}")]
     public readonly struct Option<T> : IEquatable<Option<T>> where T : unmanaged, IReference
     {
         private readonly T _v;
 
+        /// <summary>Create the instance of <see cref="Option{T}"/>.</summary>
+        /// <param name="v">original value</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Option(in T v)
         {
             _v = v;
         }
 
+        /// <summary>Get the value if exists, or it throws <see cref="InvalidOperationException"/>.</summary>
         public T Value
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -28,8 +33,12 @@ namespace U8Xml
             }
         }
 
+        /// <summary>Get whether the value exists or not.</summary>
         public bool HasValue => _v.IsNull == false;
 
+        /// <summary>Try to get a value if exists, or the method returns false.</summary>
+        /// <param name="value">a value if exists. (Don't use it if the method returns false.)</param>
+        /// <returns>succeed or not</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetValue(out T value)
         {
@@ -37,19 +46,30 @@ namespace U8Xml
             return _v.IsNull == false;
         }
 
+        /// <inheritdoc/>
         public override string ToString() => _v.IsNull ? "null" : (_v.ToString() ?? "");
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is Option<T> option && Equals(option);
 
+        /// <summary>Returns whether the value is same as the specified instance.</summary>
+        /// <param name="other">an instance to check</param>
+        /// <returns>equal or not</returns>
         public bool Equals(Option<T> other) => EqualityComparer<T>.Default.Equals(_v, other._v);
 
+        /// <summary>Returns whether the value is same as the specified instance.</summary>
+        /// <param name="other">an instance to check</param>
+        /// <returns>equal or not</returns>
         public bool Equals(in T other) => EqualityComparer<T>.Default.Equals(_v, other);
 
+        /// <inheritdoc/>
         public override int GetHashCode() => _v.GetHashCode();
 
+        /// <summary>implicit cast operation <typeparamref name="T"/> to <see cref="Option{T}"/></summary>
+        /// <param name="value">a value to cast</param>
         public static implicit operator Option<T>(in T value) => new Option<T>(value);
     }
-    
+
 
     public interface IReference
     {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Option.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Option.cs
@@ -14,6 +14,9 @@ namespace U8Xml
     {
         private readonly T _v;
 
+        /// <summary>Get empty instance of <see cref="Option{T}"/>.</summary>
+        public static Option<T> Null => default;
+
         /// <summary>Create the instance of <see cref="Option{T}"/>.</summary>
         /// <param name="v">original value</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
@@ -233,62 +233,6 @@ namespace U8Xml
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public SplitRawStrings Split(ReadOnlySpan<byte> separator) => new SplitRawStrings(this, separator);
 
-#if NET5_0_OR_GREATER
-        [SkipLocalsInit]
-#endif
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe SplitRawStrings Split(char separator)
-        {
-            if(separator < 128) {
-                return Split((byte)separator);
-            }
-            else {
-                const int CharMaxByteCount = 6;
-                byte* buf = stackalloc byte[CharMaxByteCount];
-                var byteCount = Encoding.UTF8.GetBytes(&separator, 1, buf, CharMaxByteCount);
-                return Split(SpanHelper.CreateReadOnlySpan<byte>(buf, byteCount));
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public SplitRawStrings Split(string separator) => Split(separator.AsSpan());
-
-#if NET5_0_OR_GREATER
-        [SkipLocalsInit]
-#endif
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe SplitRawStrings Split(ReadOnlySpan<char> separator)
-        {
-            const int CharMaxByteCount = 6;
-            const int StackBufSize = 128;
-            const int ThresholdLen = StackBufSize / CharMaxByteCount;
-            if(separator.Length == 1 && separator[0] < 128) {
-                return Split((byte)separator[0]);
-            }
-            if(separator.Length <= ThresholdLen) {
-                byte* buf = stackalloc byte[StackBufSize];
-                fixed(char* ptr = separator) {
-                    var byteCount = Encoding.UTF8.GetBytes(ptr, separator.Length, buf, StackBufSize);
-                    return Split(SpanHelper.CreateReadOnlySpan<byte>(buf, byteCount));
-                }
-            }
-            else {
-                var utf8 = Encoding.UTF8;
-                var byteCount = utf8.GetByteCount(separator);
-                var buf = ArrayPool<byte>.Shared.Rent(byteCount);
-                try {
-                    fixed(byte* bufPtr = buf)
-                    fixed(char* ptr = separator) {
-                        utf8.GetBytes(ptr, separator.Length, bufPtr, byteCount);
-                        return Split(SpanHelper.CreateReadOnlySpan<byte>(bufPtr, byteCount));
-                    }
-                }
-                finally {
-                    ArrayPool<byte>.Shared.Return(buf);
-                }
-            }
-        }
-
         public (RawString, RawString) Split2(byte separator)
         {
             for(int i = 0; i < _length; i++) {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
@@ -225,11 +225,32 @@ namespace U8Xml
             return value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SplitRawStrings Split(byte separator) => new SplitRawStrings(this, separator);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SplitRawStrings Split(ReadOnlySpan<byte> separator) => new SplitRawStrings(this, separator);
+
         public (RawString, RawString) Split2(byte separator)
         {
             for(int i = 0; i < _length; i++) {
                 if(((byte*)_ptr)[i] == separator) {
                     var latterStart = Math.Min(i + 1, _length);
+                    return (SliceUnsafe(0, i), SliceUnsafe(latterStart, _length - latterStart));
+                }
+            }
+            return (this, Empty);
+        }
+
+        public (RawString, RawString) Split2(ReadOnlySpan<byte> separator)
+        {
+            if((uint)separator.Length > (uint)_length) {
+                return (this, Empty);
+            }
+            var maxLoop = _length - separator.Length + 1;
+            for(int i = 0; i < maxLoop; i++) {
+                if(SliceUnsafe(i, separator.Length).SequenceEqual(separator)) {
+                    var latterStart = Math.Min(i + separator.Length, _length);
                     return (SliceUnsafe(0, i), SliceUnsafe(latterStart, _length - latterStart));
                 }
             }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
@@ -6,8 +6,8 @@ using U8Xml.Internal;
 
 namespace U8Xml
 {
-	unsafe partial struct RawString
-	{
+    unsafe partial struct RawString
+    {
         /// <summary>utf-8 bytes of "∞"</summary>
         private static ReadOnlySpan<byte> InfUtf8Str => new byte[] { 0xE2, 0x88, 0x9E };
 
@@ -107,18 +107,18 @@ namespace U8Xml
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryToInt32(out int value)
-		{
+        {
             return Utf8Parser.TryParse(AsSpan(), out value, out _);
-		}
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int ToInt32()
-		{
+        {
             if(Utf8Parser.TryParse(AsSpan(), out int value, out _) == false) {
                 ThrowHelper.ThrowInvalidOperation(InvalidFormatMessage);
             }
-			return value;
-		}
+            return value;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryToUInt32(out uint value)

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Deprecated.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Deprecated.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System;
+using System.ComponentModel;
+
+namespace U8Xml
+{
+    partial struct RawString
+    {
+        /// <summary>Use <see cref="StartsWith(RawString)"/> instead. (The correct method name is Start**s**With)</summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        [Obsolete("Use RawString.StartsWith instead. (The method name is Start*s*With)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool StartWith(RawString other) => StartsWith(other);
+
+        /// <summary>Use <see cref="StartsWith(ReadOnlySpan{byte})"/> instead. (The correct method name is Start**s**With)</summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        [Obsolete("Use RawString.StartsWith instead. (The method name is Start*s*With)")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool StartWith(ReadOnlySpan<byte> other) => StartsWith(other);
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Deprecated.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Deprecated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b57db09749c9db8448a36fcce6b5c226
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -282,6 +282,16 @@ namespace U8Xml
             }
         }
 
+        /// <summary>Compute hash code for the specified span using the same algorithm as <see cref="GetHashCode()"/>.</summary>
+        /// <param name="ptr">pointer to byte span head</param>
+        /// <param name="length">length of byte span</param>
+        /// <returns>hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(IntPtr ptr, int length)
+        {
+            return GetHashCode((byte*)ptr, length);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetHashCode(byte* ptr, int length)
         {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -268,6 +268,17 @@ namespace U8Xml
             }
         }
 
+        /// <summary>Compute hash code for the specified span using the same algorithm as <see cref="GetHashCode()"/>.</summary>
+        /// <param name="utf8String">span to compute hash code</param>
+        /// <returns>hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(ReadOnlySpan<byte> utf8String)
+        {
+            fixed(byte* ptr = utf8String) {
+                return GetHashCode(ptr, utf8String.Length);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetHashCode(byte* ptr, int length)
         {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -26,6 +26,9 @@ namespace U8Xml
         /// <summary>Get length of the byte array. (NOT length of utf-8 string)</summary>
         public int Length => _length;
 
+        /// <summary>Get pointer to the head of the utf-8 characters.</summary>
+        public IntPtr Ptr => _ptr;
+
         /// <summary>Get or set an item with specified index</summary>
         /// <param name="index">index of an item</param>
         /// <returns>the item</returns>

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -286,14 +286,27 @@ namespace U8Xml
 
         public static bool operator !=(RawString left, RawString right) => !(left == right);
 
-        public static bool operator ==(RawString left, string right)
+        public static bool operator ==(RawString left, ReadOnlySpan<byte> right) => left.SequenceEqual(right);
+
+        public static bool operator !=(RawString left, ReadOnlySpan<byte> right) => !(left == right);
+
+        public static bool operator ==(ReadOnlySpan<byte> left, RawString right) => right == left;
+
+        public static bool operator !=(ReadOnlySpan<byte> left, RawString right) => !(left == right);
+
+#if NET5_0_OR_GREATER
+        [SkipLocalsInit]
+#endif
+        public static bool operator ==(RawString left, ReadOnlySpan<char> right)
         {
-            if(right is null) { return left.IsEmpty; }
+            if(right.IsEmpty) { return left.IsEmpty; }
             var utf8 = Encoding.UTF8;
             var byteLen = utf8.GetByteCount(right);
             if(byteLen != left.Length) { return false; }
-            if(byteLen <= 128) {
-                byte* buf = stackalloc byte[byteLen];
+
+            const int Threshold = 128;
+            if(byteLen <= Threshold) {
+                byte* buf = stackalloc byte[Threshold];
                 fixed(char* ptr = right) {
                     utf8.GetBytes(ptr, right.Length, buf, byteLen);
                 }
@@ -313,6 +326,14 @@ namespace U8Xml
                 }
             }
         }
+
+        public static bool operator !=(RawString left, ReadOnlySpan<char> right) => !(left == right);
+
+        public static bool operator ==(ReadOnlySpan<char> left, RawString right) => right == left;
+
+        public static bool operator !=(ReadOnlySpan<char> left, RawString right) => !(left == right);
+
+        public static bool operator ==(RawString left, string right) => left == right.AsSpan();
 
         public static bool operator !=(RawString left, string right) => !(left == right);
 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -165,24 +165,12 @@ namespace U8Xml
 
         public bool StartWith(RawString other)
         {
-            if(_length < other.Length) { return false; }
-            for(int i = 0; i < other.Length; i++) {
-                if(At(i) != other.At(i)) {
-                    return false;
-                }
-            }
-            return true;
+            return AsSpan().StartsWith(other.AsSpan());
         }
 
         public bool StartWith(ReadOnlySpan<byte> other)
         {
-            if(_length < other.Length) { return false; }
-            for(int i = 0; i < other.Length; i++) {
-                if(At(i) != other.At(i)) {
-                    return false;
-                }
-            }
-            return true;
+            return AsSpan().StartsWith(other);
         }
 
         public bool StartWith(string other) => StartWith(other.AsSpan());

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -163,22 +163,22 @@ namespace U8Xml
 
         public bool SequenceEqual(ReadOnlySpan<byte> other) => AsSpan().SequenceEqual(other);
 
-        public bool StartWith(RawString other)
+        public bool StartsWith(RawString other)
         {
             return AsSpan().StartsWith(other.AsSpan());
         }
 
-        public bool StartWith(ReadOnlySpan<byte> other)
+        public bool StartsWith(ReadOnlySpan<byte> other)
         {
             return AsSpan().StartsWith(other);
         }
 
-        public bool StartWith(string other) => StartWith(other.AsSpan());
+        public bool StartsWith(string other) => StartsWith(other.AsSpan());
 
 #if NET5_0_OR_GREATER
         [SkipLocalsInit]
 #endif
-        public bool StartWith(ReadOnlySpan<char> other)
+        public bool StartsWith(ReadOnlySpan<char> other)
         {
             if(other.Length == 0) {
                 return true;
@@ -337,16 +337,4 @@ namespace U8Xml
             _entity = entity;
         }
     }
-
-#if NETSTANDARD2_0 || NET48
-    internal static class EncodingExtension
-    {
-        public static unsafe int GetByteCount(this Encoding encoding, ReadOnlySpan<char> span)
-        {
-            fixed(char* ptr = span) {
-                return encoding.GetByteCount(ptr, span.Length);
-            }
-        }
-    }
-#endif
 }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs
@@ -1,0 +1,99 @@
+#nullable enable
+using System;
+using System.Runtime.CompilerServices;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace U8Xml
+{
+    public readonly ref struct SplitRawStrings
+    {
+        private readonly RawString _str;
+        private readonly bool _isSeparatorChar;
+        private readonly byte _separatorChar;
+        private readonly ReadOnlySpan<byte> _separatorStr;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SplitRawStrings(RawString str, byte separator)
+        {
+            _str = str;
+            _isSeparatorChar = true;
+            _separatorChar = separator;
+            _separatorStr = default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SplitRawStrings(RawString str, ReadOnlySpan<byte> separator)
+        {
+            _str = str;
+            _isSeparatorChar = false;
+            _separatorChar = default;
+            _separatorStr = separator;
+        }
+
+        public IEnumerable<RawString> AsEnumerable()
+        {
+            var list = new List<RawString>();
+            foreach(var s in this) {
+                list.Add(s);
+            }
+            return list;
+        }
+
+        public RawString[] ToArray()
+        {
+            return AsEnumerable().ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() => _isSeparatorChar ? new Enumerator(_str, _separatorChar) : new Enumerator(_str, _separatorStr);
+
+        public ref struct Enumerator
+        {
+            private RawString _str;
+            private RawString _current;
+            private readonly bool _isSeparatorChar;
+            private readonly byte _separatorChar;
+            private readonly ReadOnlySpan<byte> _separatorStr;
+
+            public RawString Current => _current;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Enumerator(RawString str, byte separator)
+            {
+                _str = str;
+                _current = RawString.Empty;
+                _isSeparatorChar = true;
+                _separatorChar = separator;
+                _separatorStr = default;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Enumerator(RawString str, ReadOnlySpan<byte> separator)
+            {
+                _str = str;
+                _current = RawString.Empty;
+                _isSeparatorChar = false;
+                _separatorChar = default;
+                _separatorStr = separator;
+            }
+
+            public void Dispose() { }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext()
+            {
+                if(_str.IsEmpty) {
+                    return false;
+                }
+                if(_isSeparatorChar) {
+                    (_current, _str) = _str.Split2(_separatorChar);
+                }
+                else {
+                    (_current, _str) = _str.Split2(_separatorStr);
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs
@@ -9,26 +9,26 @@ namespace U8Xml
     public readonly ref struct SplitRawStrings
     {
         private readonly RawString _str;
-        private readonly bool _isSeparatorChar;
-        private readonly byte _separatorChar;
-        private readonly ReadOnlySpan<byte> _separatorStr;
+        private readonly bool _isSeparatorSingleByte;
+        private readonly byte _separator;
+        private readonly ReadOnlySpan<byte> _spanSeparator;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public SplitRawStrings(RawString str, byte separator)
         {
             _str = str;
-            _isSeparatorChar = true;
-            _separatorChar = separator;
-            _separatorStr = default;
+            _isSeparatorSingleByte = true;
+            _separator = separator;
+            _spanSeparator = default;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public SplitRawStrings(RawString str, ReadOnlySpan<byte> separator)
         {
             _str = str;
-            _isSeparatorChar = false;
-            _separatorChar = default;
-            _separatorStr = separator;
+            _isSeparatorSingleByte = false;
+            _separator = default;
+            _spanSeparator = separator;
         }
 
         public IEnumerable<RawString> AsEnumerable()
@@ -46,7 +46,7 @@ namespace U8Xml
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Enumerator GetEnumerator() => _isSeparatorChar ? new Enumerator(_str, _separatorChar) : new Enumerator(_str, _separatorStr);
+        public Enumerator GetEnumerator() => _isSeparatorSingleByte ? new Enumerator(_str, _separator) : new Enumerator(_str, _spanSeparator);
 
         public ref struct Enumerator
         {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/SplitRawStrings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 632a8f8f566456b43a2bef2fca61f1f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
@@ -37,7 +37,7 @@ namespace U8Xml
 
         public override string ToString() => _attr == IntPtr.Zero ? "" : ((XmlAttribute_*)_attr)->ToString();
 
-        public static implicit operator ValueTuple<RawString, RawString>(XmlAttribute attr) => (attr.Name, attr.Value);
+        public static implicit operator (RawString Name, RawString Value)(XmlAttribute attr) => (attr.Name, attr.Value);
 
         public static bool operator ==(XmlAttribute attr, ValueTuple<RawString, RawString> pair) => attr.Name == pair.Item1 && attr.Value == pair.Item2;
         public static bool operator !=(XmlAttribute attr, ValueTuple<RawString, RawString> pair) => !(attr == pair);

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
@@ -103,5 +103,25 @@ namespace U8Xml
             }
             return attr;
         }
+
+        public static bool TryFindName<TAttributes>(this TAttributes source, RawString name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+        }
+
+        public static bool TryFindName<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+        }
+
+        public static bool TryFindName<TAttributes>(this TAttributes source, string name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+        }
+
+        public static bool TryFindName<TAttributes>(this TAttributes source, ReadOnlySpan<char> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+        }
     }
 }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
@@ -14,7 +14,7 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
+        public static Option<XmlAttribute> FindOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
         {
             foreach(var attr in source) {
                 if(attr.Name == name) {
@@ -28,16 +28,16 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
+        public static Option<XmlAttribute> FindOrDefault<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name.AsSpan());
+            return FindOrDefault(source, name.AsSpan());
         }
 
         /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
+        public static Option<XmlAttribute> FindOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
         {
             foreach(var attr in source) {
                 if(attr.Name == name) {
@@ -51,18 +51,18 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
+        public static Option<XmlAttribute> FindOrDefault<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name.AsSpan());
+            return FindOrDefault(source, name.AsSpan());
         }
 
         /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static XmlAttribute FindName<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
+        public static XmlAttribute Find<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var attr) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return attr;
@@ -72,9 +72,9 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static XmlAttribute FindName<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
+        public static XmlAttribute Find<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var attr) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return attr;
@@ -84,9 +84,9 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static XmlAttribute FindName<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
+        public static XmlAttribute Find<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var attr) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return attr;
@@ -96,32 +96,32 @@ namespace U8Xml
         /// <param name="source">source list to enumerate</param>
         /// <param name="name">attribute name to find</param>
         /// <returns>a found attribute as <see cref="Option{T}"/></returns>
-        public static XmlAttribute FindName<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
+        public static XmlAttribute Find<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var attr) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return attr;
         }
 
-        public static bool TryFindName<TAttributes>(this TAttributes source, RawString name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        public static bool TryFind<TAttributes>(this TAttributes source, RawString name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+            return FindOrDefault(source, name).TryGetValue(out attribute);
         }
 
-        public static bool TryFindName<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        public static bool TryFind<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+            return FindOrDefault(source, name).TryGetValue(out attribute);
         }
 
-        public static bool TryFindName<TAttributes>(this TAttributes source, string name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        public static bool TryFind<TAttributes>(this TAttributes source, string name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+            return FindOrDefault(source, name).TryGetValue(out attribute);
         }
 
-        public static bool TryFindName<TAttributes>(this TAttributes source, ReadOnlySpan<char> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
+        public static bool TryFind<TAttributes>(this TAttributes source, ReadOnlySpan<char> name, out XmlAttribute attribute) where TAttributes : IEnumerable<XmlAttribute>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out attribute);
+            return FindOrDefault(source, name).TryGetValue(out attribute);
         }
     }
 }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using U8Xml.Internal;
+
+namespace U8Xml
+{
+    /// <summary>Privides extensions of <see cref="XmlAttribute"/> enumeration.</summary>
+    public static class XmlAttributeEnumerableExtension
+    {
+        private const string NoMatchingMessage = "Sequence contains no matching elements.";
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            foreach(var attr in source) {
+                if(attr.Name == name) {
+                    return attr;
+                }
+            }
+            return Option<XmlAttribute>.Null;
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name.AsSpan());
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            foreach(var attr in source) {
+                if(attr.Name == name) {
+                    return attr;
+                }
+            }
+            return Option<XmlAttribute>.Null;
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static Option<XmlAttribute> FindNameOrDefault<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            return FindNameOrDefault(source, name.AsSpan());
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static XmlAttribute FindName<TAttributes>(this TAttributes source, ReadOnlySpan<byte> name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return attr;
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static XmlAttribute FindName<TAttributes>(this TAttributes source, RawString name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return attr;
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static XmlAttribute FindName<TAttributes>(this TAttributes source, ReadOnlySpan<char> name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return attr;
+        }
+
+        /// <summary>Find an attribute by name. Returns the first attribute found.</summary>
+        /// <param name="source">source list to enumerate</param>
+        /// <param name="name">attribute name to find</param>
+        /// <returns>a found attribute as <see cref="Option{T}"/></returns>
+        public static XmlAttribute FindName<TAttributes>(this TAttributes source, string name) where TAttributes : IEnumerable<XmlAttribute>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var attr) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return attr;
+        }
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdc7fa32d568d644fa0a070df09d5d64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -56,6 +56,11 @@ namespace U8Xml
 
         internal XmlNode(XmlNode_* node) => _node = (IntPtr)node;
 
+        public bool TryGetParent(out XmlNode parent) => Parent.TryGetValue(out parent);
+        public bool TryGetFirstChild(out XmlNode firstChild) => FirstChild.TryGetValue(out firstChild);
+        public bool TryGetLastChild(out XmlNode lastChild) => LastChild.TryGetValue(out lastChild);
+        public bool TryNextSibling(out XmlNode nextSibling) => NextSibling.TryGetValue(out nextSibling);
+
         /// <summary>Find a child by name. Returns the first child found.</summary>
         /// <param name="name">child name to find</param>
         /// <returns>a found child node as <see cref="Option{T}"/></returns>
@@ -123,6 +128,26 @@ namespace U8Xml
             }
             return node;
         }
+
+        public bool TryFindChild(ReadOnlySpan<byte> name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
+        public bool TryFindChild(RawString name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
+        public bool TryFindChild(ReadOnlySpan<char> name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
+        public bool TryFindChild(string name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
+
+        public Option<XmlAttribute> FindAttributeOrDefault(RawString name) => Attributes.FindNameOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<byte> name) => Attributes.FindNameOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(string name) => Attributes.FindNameOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<char> name) => Attributes.FindNameOrDefault(name);
+
+        public XmlAttribute FindAttribute(RawString name) => Attributes.FindName(name);
+        public XmlAttribute FindAttribute(ReadOnlySpan<byte> name) => Attributes.FindName(name);
+        public XmlAttribute FindAttribute(string name) => Attributes.FindName(name);
+        public XmlAttribute FindAttribute(ReadOnlySpan<char> name) => Attributes.FindName(name);
+
+        public bool TryFindAttribute(RawString name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
+        public bool TryFindAttribute(ReadOnlySpan<byte> name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
+        public bool TryFindAttribute(string name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
+        public bool TryFindAttribute(ReadOnlySpan<char> name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is XmlNode node && Equals(node);

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -134,20 +134,20 @@ namespace U8Xml
         public bool TryFindChild(ReadOnlySpan<char> name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
         public bool TryFindChild(string name, out XmlNode node) => FindChildOrDefault(name).TryGetValue(out node);
 
-        public Option<XmlAttribute> FindAttributeOrDefault(RawString name) => Attributes.FindNameOrDefault(name);
-        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<byte> name) => Attributes.FindNameOrDefault(name);
-        public Option<XmlAttribute> FindAttributeOrDefault(string name) => Attributes.FindNameOrDefault(name);
-        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<char> name) => Attributes.FindNameOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(RawString name) => Attributes.FindOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<byte> name) => Attributes.FindOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(string name) => Attributes.FindOrDefault(name);
+        public Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<char> name) => Attributes.FindOrDefault(name);
 
-        public XmlAttribute FindAttribute(RawString name) => Attributes.FindName(name);
-        public XmlAttribute FindAttribute(ReadOnlySpan<byte> name) => Attributes.FindName(name);
-        public XmlAttribute FindAttribute(string name) => Attributes.FindName(name);
-        public XmlAttribute FindAttribute(ReadOnlySpan<char> name) => Attributes.FindName(name);
+        public XmlAttribute FindAttribute(RawString name) => Attributes.Find(name);
+        public XmlAttribute FindAttribute(ReadOnlySpan<byte> name) => Attributes.Find(name);
+        public XmlAttribute FindAttribute(string name) => Attributes.Find(name);
+        public XmlAttribute FindAttribute(ReadOnlySpan<char> name) => Attributes.Find(name);
 
-        public bool TryFindAttribute(RawString name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
-        public bool TryFindAttribute(ReadOnlySpan<byte> name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
-        public bool TryFindAttribute(string name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
-        public bool TryFindAttribute(ReadOnlySpan<char> name, out XmlAttribute attribute) => Attributes.TryFindName(name, out attribute);
+        public bool TryFindAttribute(RawString name, out XmlAttribute attribute) => Attributes.TryFind(name, out attribute);
+        public bool TryFindAttribute(ReadOnlySpan<byte> name, out XmlAttribute attribute) => Attributes.TryFind(name, out attribute);
+        public bool TryFindAttribute(string name, out XmlAttribute attribute) => Attributes.TryFind(name, out attribute);
+        public bool TryFindAttribute(ReadOnlySpan<char> name, out XmlAttribute attribute) => Attributes.TryFind(name, out attribute);
 
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is XmlNode node && Equals(node);

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -6,44 +6,77 @@ using U8Xml.Internal;
 
 namespace U8Xml
 {
+    /// <summary>A xml node type.</summary>
     [DebuggerDisplay("<{ToString(),nq}>")]
     public readonly unsafe struct XmlNode : IEquatable<XmlNode>, IReference
     {
         private readonly IntPtr _node;  // XmlNode_*
 
+        /// <summary>Get whether the node is null. (Valid nodes always return false.)</summary>
         public bool IsNull => _node == IntPtr.Zero;
 
+        /// <summary>Get name of the node.</summary>
         public RawString Name => ((XmlNode_*)_node)->Name;
+
+        /// <summary>Get an inner text of the node.</summary>
         public RawString InnerText => ((XmlNode_*)_node)->InnerText;
+
+        /// <summary>Get whether the node has any attribute.</summary>
         public bool HasAttribute => ((XmlNode_*)_node)->HasAttribute;
+
+        /// <summary>Get attributes of the node.</summary>
         public XmlAttributeList Attributes => ((XmlNode_*)_node)->Attributes;
+
+        /// <summary>Get whether the node has any children.</summary>
         public bool HasChildren => ((XmlNode_*)_node)->HasChildren;
+
+        /// <summary>Get children of the node.</summary>
         public XmlNodeList Children => new XmlNodeList((XmlNode_*)_node);
 
+        /// <summary>Get descendant nodes in the way of depth-first search.</summary>
+        public XmlNodeDescendantList Descendants => new XmlNodeDescendantList((XmlNode_*)_node);
+
+        /// <summary>Get depth of the node in xml. (The root node is 0.)</summary>
+        public int Depth => ((XmlNode_*)_node)->Depth;
+
+        /// <summary>Get whether the node is root.</summary>
         public bool IsRoot => ((XmlNode_*)_node)->Parent == null;
 
+        /// <summary>Get a parent node of the node.</summary>
         public Option<XmlNode> Parent => new XmlNode(((XmlNode_*)_node)->Parent);
 
+        /// <summary>Get the first child node.</summary>
         public Option<XmlNode> FirstChild => new XmlNode(((XmlNode_*)_node)->FirstChild);
 
+        /// <summary>Get the last child of the node.</summary>
         public Option<XmlNode> LastChild => new XmlNode(((XmlNode_*)_node)->LastChild);
 
+        /// <summary>Get the next sibling of the node.</summary>
         public Option<XmlNode> NextSibling => new XmlNode(((XmlNode_*)_node)->Sibling);
 
         internal XmlNode(XmlNode_* node) => _node = (IntPtr)node;
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is XmlNode node && Equals(node);
 
+        /// <summary>Returns whether the value is same as the specified instance.</summary>
+        /// <param name="other">an instance to check</param>
+        /// <returns>equal or not</returns>s
         public bool Equals(XmlNode other) => _node == other._node;
 
+        /// <inheritdoc/>
         public override int GetHashCode() => _node.GetHashCode();
 
+        /// <inheritdoc/>
         public override string ToString() => _node != IntPtr.Zero ? ((XmlNode_*)_node)->Name.ToString() : "";
     }
 
     [DebuggerDisplay("{ToString(),nq}")]
     internal unsafe struct XmlNode_
     {
+        private readonly IntPtr _wholeNodes;    // Its type is CustomList<XmlNode_>, but the field is IntPtr. *** See the comment in the constructor ***
+        public readonly int NodeIndex;
+        public readonly int Depth;
         public readonly RawString Name;
         public RawString InnerText;
 
@@ -57,6 +90,12 @@ namespace U8Xml
         public int AttrCount;
         private readonly CustomList<XmlAttribute_> _wholeAttrs;
 
+        public readonly CustomList<XmlNode_> WholeNodes
+        {
+            // See the comment in the constructor to know what the following means.
+            get => Unsafe.As<IntPtr, CustomList<XmlNode_>>(ref Unsafe.AsRef(_wholeNodes));
+        }
+
         public bool HasAttribute => AttrCount > 0;
 
         public bool HasChildren => FirstChild != null;
@@ -68,8 +107,19 @@ namespace U8Xml
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal XmlNode_(RawString name, CustomList<XmlAttribute_> wholeAttrs)
+        internal XmlNode_(CustomList<XmlNode_> wholeNodes, int nodeIndex, int depth, RawString name, CustomList<XmlAttribute_> wholeAttrs)
         {
+            // [NOTE]
+            // _wholeNodes is CustomList<XmlNode_>,
+            // but XmlNode_ cannot have any fields of type CustomList<XmlNode_> because of the bug of the dotnet runtime.
+            // CustomList<XmlNode_> has same memory layout as IntPtr.
+            // So XmlNode_ has 'wholeNodes' as IntPtr.
+
+            Debug.Assert(sizeof(CustomList<XmlNode_>) == sizeof(IntPtr));
+            _wholeNodes = Unsafe.As<CustomList<XmlNode_>, IntPtr>(ref wholeNodes);
+
+            NodeIndex = nodeIndex;
+            Depth = depth;
             Name = name;
             InnerText = RawString.Empty;
             Parent = null;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -56,6 +56,74 @@ namespace U8Xml
 
         internal XmlNode(XmlNode_* node) => _node = (IntPtr)node;
 
+        /// <summary>Find a child by name. Returns the first child found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node as <see cref="Option{T}"/></returns>
+        public Option<XmlNode> FindChildOrDefault(RawString name) => FindChildOrDefault(name.AsSpan());
+
+        /// <summary>Find a child by name. Returns the first child found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node as <see cref="Option{T}"/></returns>
+        public Option<XmlNode> FindChildOrDefault(ReadOnlySpan<byte> name)
+        {
+            foreach(var child in Children) {
+                if(child.Name == name) {
+                    return child;
+                }
+            }
+            return Option<XmlNode>.Null;
+        }
+
+        /// <summary>Find a child by name. Returns the first child found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node as <see cref="Option{T}"/></returns>
+        public Option<XmlNode> FindChildOrDefault(string name) => FindChildOrDefault(name.AsSpan());
+
+        /// <summary>Find a child by name. Returns the first child found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node as <see cref="Option{T}"/></returns>
+        public Option<XmlNode> FindChildOrDefault(ReadOnlySpan<char> name)
+        {
+            foreach(var child in Children) {
+                if(child.Name == name) {
+                    return child;
+                }
+            }
+            return Option<XmlNode>.Null;
+        }
+
+        /// <summary>Find a child by name. Returns the first child found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node</returns>
+        public XmlNode FindChild(RawString name) => FindChild(name.AsSpan());
+
+        /// <summary>Find a child by name. Returns the first child found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node</returns>
+        public XmlNode FindChild(ReadOnlySpan<byte> name)
+        {
+            if(FindChildOrDefault(name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation("Sequence contains no matching elements.");
+            }
+            return node;
+        }
+
+        /// <summary>Find a child by name. Returns the first child found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node</returns>
+        public XmlNode FindChild(string name) => FindChild(name.AsSpan());
+
+        /// <summary>Find a child by name. Returns the first child found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="name">child name to find</param>
+        /// <returns>a found child node</returns>
+        public XmlNode FindChild(ReadOnlySpan<char> name)
+        {
+            if(FindChildOrDefault(name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation("Sequence contains no matching elements.");
+            }
+            return node;
+        }
+
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is XmlNode node && Equals(node);
 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeDescendantList.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeDescendantList.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using U8Xml.Internal;
+
+namespace U8Xml
+{
+    public unsafe readonly struct XmlNodeDescendantList : IEnumerable<XmlNode>
+    {
+        private readonly XmlNode_* _parent;
+
+        internal XmlNodeDescendantList(XmlNode_* parent)
+        {
+            Debug.Assert(parent != null);
+            _parent = parent;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Enumerator GetEnumerator() => new Enumerator(_parent);
+
+        IEnumerator<XmlNode> IEnumerable<XmlNode>.GetEnumerator() => new EnumeratorClass(_parent);
+
+        IEnumerator IEnumerable.GetEnumerator() => new EnumeratorClass(_parent);
+
+        public struct Enumerator : IEnumerator<XmlNode>
+        {
+            private CustomList<XmlNode_>.Enumerator _e;     // Don't make it readonly.
+            private readonly int _depth;
+
+            public XmlNode Current => new XmlNode(_e.Current);
+
+            object IEnumerator.Current => Current;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal Enumerator(XmlNode_* parent)
+            {
+                var firstChild = parent->FirstChild;
+                if(firstChild == null) {
+                    this = default;         // default instance is valid.
+                }
+                else {
+                    _e = parent->WholeNodes.GetEnumerator(firstChild->NodeIndex);
+                    _depth = parent->Depth;
+                }
+            }
+
+            public void Dispose() => _e.Dispose();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext()
+            {
+                if(_e.MoveNext() == false) {
+                    return false;
+                }
+                if(_e.Current->Depth <= _depth) {
+                    return false;
+                }
+                return true;
+            }
+
+            public void Reset() => _e.Reset();
+        }
+
+        private sealed class EnumeratorClass : IEnumerator<XmlNode>
+        {
+            private Enumerator _e;  // Don't make it readonly.
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal EnumeratorClass(XmlNode_* parent)
+            {
+                _e = new Enumerator(parent);
+            }
+
+            public XmlNode Current => _e.Current;
+
+            object IEnumerator.Current => _e.Current;
+
+            public void Dispose() => _e.Dispose();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool MoveNext() => _e.MoveNext();
+
+            public void Reset() => _e.Reset();
+        }
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeDescendantList.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeDescendantList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 932607c081f698c47b1523386a46c731
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
@@ -103,5 +103,25 @@ namespace U8Xml
             }
             return node;
         }
+
+        public static bool TryFindName<TNodes>(this TNodes source, ReadOnlySpan<byte> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out node);
+        }
+
+        public static bool TryFindName<TNodes>(this TNodes source, RawString name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out node);
+        }
+
+        public static bool TryFindName<TNodes>(this TNodes source, ReadOnlySpan<char> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out node);
+        }
+
+        public static bool TryFindName<TNodes>(this TNodes source, string name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name).TryGetValue(out node);
+        }
     }
 }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using U8Xml.Internal;
+
+namespace U8Xml
+{
+    /// <summary>Privides extensions of <see cref="XmlNode"/> enumeration.</summary>
+    public static class XmlNodeEnumerableExtension
+    {
+        private const string NoMatchingMessage = "Sequence contains no matching elements.";
+
+        /// <summary>Find a node by name. Returns the first node found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node as <see cref="Option{T}"/></returns>
+        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
+        {
+            foreach(var child in source) {
+                if(child.Name == name) {
+                    return child;
+                }
+            }
+            return Option<XmlNode>.Null;
+        }
+
+        /// <summary>Find a node by name. Returns the first node found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node as <see cref="Option{T}"/></returns>
+        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name.AsSpan());
+        }
+
+        /// <summary>Find a node by name. Returns the first node found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node as <see cref="Option{T}"/></returns>
+        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
+        {
+            foreach(var child in source) {
+                if(child.Name == name) {
+                    return child;
+                }
+            }
+            return Option<XmlNode>.Null;
+        }
+
+        /// <summary>Find a node by name. Returns the first node found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node as <see cref="Option{T}"/></returns>
+        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
+        {
+            return FindNameOrDefault(source, name.AsSpan());
+        }
+
+        /// <summary>Find a node by name. Returns the first node found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node</returns>
+        public static XmlNode FindName<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return node;
+        }
+
+        /// <summary>Find a node by name. Returns the first node found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node</returns>
+        public static XmlNode FindName<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return node;
+        }
+
+        /// <summary>Find a node by name. Returns the first node found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node</returns>
+        public static XmlNode FindName<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return node;
+        }
+
+        /// <summary>Find a node by name. Returns the first node found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
+        /// <param name="source">source node list to enumerate</param>
+        /// <param name="name">node name to find</param>
+        /// <returns>a found node</returns>
+        public static XmlNode FindName<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
+        {
+            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+                ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
+            }
+            return node;
+        }
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
@@ -14,7 +14,7 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node as <see cref="Option{T}"/></returns>
-        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
+        public static Option<XmlNode> FindOrDefault<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
         {
             foreach(var child in source) {
                 if(child.Name == name) {
@@ -28,16 +28,16 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node as <see cref="Option{T}"/></returns>
-        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
+        public static Option<XmlNode> FindOrDefault<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name.AsSpan());
+            return FindOrDefault(source, name.AsSpan());
         }
 
         /// <summary>Find a node by name. Returns the first node found.</summary>
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node as <see cref="Option{T}"/></returns>
-        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
+        public static Option<XmlNode> FindOrDefault<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
         {
             foreach(var child in source) {
                 if(child.Name == name) {
@@ -51,18 +51,18 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node as <see cref="Option{T}"/></returns>
-        public static Option<XmlNode> FindNameOrDefault<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
+        public static Option<XmlNode> FindOrDefault<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name.AsSpan());
+            return FindOrDefault(source, name.AsSpan());
         }
 
         /// <summary>Find a node by name. Returns the first node found, or throws <see cref="InvalidOperationException"/> if not found.</summary>
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node</returns>
-        public static XmlNode FindName<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
+        public static XmlNode Find<TNodes>(this TNodes source, ReadOnlySpan<byte> name) where TNodes : IEnumerable<XmlNode>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var node) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return node;
@@ -72,9 +72,9 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node</returns>
-        public static XmlNode FindName<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
+        public static XmlNode Find<TNodes>(this TNodes source, RawString name) where TNodes : IEnumerable<XmlNode>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var node) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return node;
@@ -84,9 +84,9 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node</returns>
-        public static XmlNode FindName<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
+        public static XmlNode Find<TNodes>(this TNodes source, ReadOnlySpan<char> name) where TNodes : IEnumerable<XmlNode>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var node) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return node;
@@ -96,32 +96,32 @@ namespace U8Xml
         /// <param name="source">source node list to enumerate</param>
         /// <param name="name">node name to find</param>
         /// <returns>a found node</returns>
-        public static XmlNode FindName<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
+        public static XmlNode Find<TNodes>(this TNodes source, string name) where TNodes : IEnumerable<XmlNode>
         {
-            if(FindNameOrDefault(source, name).TryGetValue(out var node) == false) {
+            if(FindOrDefault(source, name).TryGetValue(out var node) == false) {
                 ThrowHelper.ThrowInvalidOperation(NoMatchingMessage);
             }
             return node;
         }
 
-        public static bool TryFindName<TNodes>(this TNodes source, ReadOnlySpan<byte> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        public static bool TryFind<TNodes>(this TNodes source, ReadOnlySpan<byte> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out node);
+            return FindOrDefault(source, name).TryGetValue(out node);
         }
 
-        public static bool TryFindName<TNodes>(this TNodes source, RawString name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        public static bool TryFind<TNodes>(this TNodes source, RawString name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out node);
+            return FindOrDefault(source, name).TryGetValue(out node);
         }
 
-        public static bool TryFindName<TNodes>(this TNodes source, ReadOnlySpan<char> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        public static bool TryFind<TNodes>(this TNodes source, ReadOnlySpan<char> name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out node);
+            return FindOrDefault(source, name).TryGetValue(out node);
         }
 
-        public static bool TryFindName<TNodes>(this TNodes source, string name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
+        public static bool TryFind<TNodes>(this TNodes source, string name, out XmlNode node) where TNodes : IEnumerable<XmlNode>
         {
-            return FindNameOrDefault(source, name).TryGetValue(out node);
+            return FindOrDefault(source, name).TryGetValue(out node);
         }
     }
 }

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 329019aa70221ba4d8baaef504a2e8d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
@@ -223,8 +223,8 @@ namespace U8Xml
                 }
                 else {
                     GetNodeName(data, ref i, out var name);
-                    var node = nodes.GetPointerToAdd();
-                    *node = new XmlNode_(name, attrs);
+                    var node = nodes.GetPointerToAdd(out var nodeIndex);
+                    *node = new XmlNode_(nodes, nodeIndex, nodeStack.Count, name, attrs);
                     while(true) {
                         if(data.At(i) == '>') {
                             if(nodeStack.Count > 0) {
@@ -243,7 +243,7 @@ namespace U8Xml
                             goto None;
                         }
                         else {
-                            var attr = attrs.GetPointerToAdd();
+                            var attr = attrs.GetPointerToAdd(out _);
                             *attr = GetAttr(data, ref i);
                             if(node->HasAttribute == false) {
                                 node->AttrIndex = attrs.Count - 1;
@@ -501,7 +501,7 @@ namespace U8Xml
                     return true;
                 }
                 else {
-                    var attr = attrs.GetPointerToAdd();
+                    var attr = attrs.GetPointerToAdd(out _);
                     *attr = GetAttr(data, ref i);
 
                     // const utf-8 string. They are embedded in the dll.

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
@@ -293,7 +293,7 @@ namespace U8Xml
             // <!DOCTYPE foo[...]>
             ReadOnlySpan<byte> DocTypeStr = stackalloc byte[] { (byte)'D', (byte)'O', (byte)'C', (byte)'T', (byte)'Y', (byte)'P', (byte)'E', (byte)' ' };
 
-            if(data.Slice(i).StartWith(DocTypeStr) == false) { return false; }
+            if(data.Slice(i).StartsWith(DocTypeStr) == false) { return false; }
             if(hasNode) {
                 ThrowHelper.ThrowFormatException("DTD must be defined before the document root element.");
             }

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -357,7 +357,7 @@ namespace UnitTest
         }
 
         [Fact]
-        public void StartWith()
+        public void StartsWith()
         {
             const string str1 = "あいうえお";
             const string str2 = "あいう";
@@ -369,49 +369,49 @@ namespace UnitTest
             // [Assert true]
             {
                 // "あいうえお" starts with "あいうえお"
-                Assert.True(rawStr1.StartWith(rawStr1));                    // RawString -- RawString
-                Assert.True(rawStr1.StartWith(rawStr1.AsSpan()));           // RawString -- ReadOnlySpan<byte>
-                Assert.True(rawStr1.StartWith(str1));                       // RawString -- string
-                Assert.True(rawStr1.StartWith(str1.AsSpan()));              // RawString -- ReadOnlySpan<char>
+                Assert.True(rawStr1.StartsWith(rawStr1));                    // RawString -- RawString
+                Assert.True(rawStr1.StartsWith(rawStr1.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartsWith(str1));                       // RawString -- string
+                Assert.True(rawStr1.StartsWith(str1.AsSpan()));              // RawString -- ReadOnlySpan<char>
 
                 // "あいうえお" starts with "あいう"
-                Assert.True(rawStr1.StartWith(rawStr2));                    // RawString -- RawString
-                Assert.True(rawStr1.StartWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
-                Assert.True(rawStr1.StartWith(str2));                       // RawString -- string
-                Assert.True(rawStr1.StartWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
+                Assert.True(rawStr1.StartsWith(rawStr2));                    // RawString -- RawString
+                Assert.True(rawStr1.StartsWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartsWith(str2));                       // RawString -- string
+                Assert.True(rawStr1.StartsWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
 
                 // "あいうえお" starts with ""
-                Assert.True(rawStr1.StartWith(RawString.Empty));            // RawString -- RawString
-                Assert.True(rawStr1.StartWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
-                Assert.True(rawStr1.StartWith(string.Empty));               // RawString -- string
-                Assert.True(rawStr1.StartWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
+                Assert.True(rawStr1.StartsWith(RawString.Empty));            // RawString -- RawString
+                Assert.True(rawStr1.StartsWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartsWith(string.Empty));               // RawString -- string
+                Assert.True(rawStr1.StartsWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
 
                 // "あいう" starts with "あいう"
-                Assert.True(rawStr2.StartWith(rawStr2));                    // RawString -- RawString
-                Assert.True(rawStr2.StartWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
-                Assert.True(rawStr2.StartWith(str2));                       // RawString -- string
-                Assert.True(rawStr2.StartWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
+                Assert.True(rawStr2.StartsWith(rawStr2));                    // RawString -- RawString
+                Assert.True(rawStr2.StartsWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.StartsWith(str2));                       // RawString -- string
+                Assert.True(rawStr2.StartsWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
 
                 // "あいう" starts with ""
-                Assert.True(rawStr2.StartWith(RawString.Empty));            // RawString -- RawString
-                Assert.True(rawStr2.StartWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
-                Assert.True(rawStr2.StartWith(string.Empty));               // RawString -- string
-                Assert.True(rawStr2.StartWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
+                Assert.True(rawStr2.StartsWith(RawString.Empty));            // RawString -- RawString
+                Assert.True(rawStr2.StartsWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.StartsWith(string.Empty));               // RawString -- string
+                Assert.True(rawStr2.StartsWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
             }
 
             // [Assert false]
             {
                 // "あいうえお" does not start with "えお"
-                Assert.False(rawStr1.StartWith(rawStr3));                    // RawString -- RawString
-                Assert.False(rawStr1.StartWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
-                Assert.False(rawStr1.StartWith(str3));                       // RawString -- string
-                Assert.False(rawStr1.StartWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
+                Assert.False(rawStr1.StartsWith(rawStr3));                    // RawString -- RawString
+                Assert.False(rawStr1.StartsWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr1.StartsWith(str3));                       // RawString -- string
+                Assert.False(rawStr1.StartsWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
 
                 // "あいう" does not start with "えお"
-                Assert.False(rawStr2.StartWith(rawStr3));                    // RawString -- RawString
-                Assert.False(rawStr2.StartWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
-                Assert.False(rawStr2.StartWith(str3));                       // RawString -- string
-                Assert.False(rawStr2.StartWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
+                Assert.False(rawStr2.StartsWith(rawStr3));                    // RawString -- RawString
+                Assert.False(rawStr2.StartsWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr2.StartsWith(str3));                       // RawString -- string
+                Assert.False(rawStr2.StartsWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
             }
         }
 

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -407,7 +407,7 @@ namespace UnitTest
                 Assert.False(rawStr1.StartWith(str3));                       // RawString -- string
                 Assert.False(rawStr1.StartWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
 
-                // "あいう" starts with "えお"
+                // "あいう" does not start with "えお"
                 Assert.False(rawStr2.StartWith(rawStr3));                    // RawString -- RawString
                 Assert.False(rawStr2.StartWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
                 Assert.False(rawStr2.StartWith(str3));                       // RawString -- string

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -479,12 +479,15 @@ namespace UnitTest
         {
             var rawStr1 = RawStringSource.Get("あいうえお");
             Assert.True(rawStr1.GetHashCode() == RawString.GetHashCode(rawStr1.AsSpan()));
+            Assert.True(rawStr1.GetHashCode() == RawString.GetHashCode(rawStr1.Ptr, rawStr1.Length));
 
             var rawStr2 = RawStringSource.Get("hoge");
             Assert.True(rawStr2.GetHashCode() == RawString.GetHashCode(rawStr2.AsSpan()));
+            Assert.True(rawStr2.GetHashCode() == RawString.GetHashCode(rawStr2.Ptr, rawStr2.Length));
 
             var rawStr3 = RawString.Empty;
             Assert.True(rawStr3.GetHashCode() == RawString.GetHashCode(rawStr3.AsSpan()));
+            Assert.True(rawStr3.GetHashCode() == RawString.GetHashCode(rawStr3.Ptr, rawStr3.Length));
         }
 
         private readonly struct Check<T>

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -474,6 +474,19 @@ namespace UnitTest
             }
         }
 
+        [Fact]
+        public void GetHashCodeTest()
+        {
+            var rawStr1 = RawStringSource.Get("あいうえお");
+            Assert.True(rawStr1.GetHashCode() == RawString.GetHashCode(rawStr1.AsSpan()));
+
+            var rawStr2 = RawStringSource.Get("hoge");
+            Assert.True(rawStr2.GetHashCode() == RawString.GetHashCode(rawStr2.AsSpan()));
+
+            var rawStr3 = RawString.Empty;
+            Assert.True(rawStr3.GetHashCode() == RawString.GetHashCode(rawStr3.AsSpan()));
+        }
+
         private readonly struct Check<T>
         {
             public readonly T Answer;
@@ -483,7 +496,7 @@ namespace UnitTest
             public void Deconstruct(out T ans, out RawString input) => (ans, input) = (Answer, Input);
         }
     }
-    
+
     internal static partial class RawStringSource
     {
         private static readonly Dictionary<string, RawString> _dic;

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -317,7 +317,7 @@ namespace UnitTest
         }
 
         [Fact]
-        public void Split2_Char()
+        public void Split2_byte()
         {
             {
                 var ab_cd = RawStringSource.Get("ab cd");
@@ -341,10 +341,55 @@ namespace UnitTest
         }
 
         [Fact]
-        public void Split2_Str()
+        public void Split2_char()
+        {
+            {
+                var ab_cd = RawStringSource.Get("ab cd");
+                const char separator = ' ';
+                var (ab, cd) = ab_cd.Split2(separator);
+                Assert.True(ab == ab_cd.Slice(0, 2));
+                Assert.True(cd == ab_cd.Slice(3, 2));
+            }
+            {
+                var ab_cd_ef_gh = RawStringSource.Get("ab cd ef gh");
+                const char separator = ' ';
+                var (ab, cd_ef_gh) = ab_cd_ef_gh.Split2(separator);
+                Assert.True(ab == ab_cd_ef_gh.Slice(0, 2));
+                Assert.True(cd_ef_gh == ab_cd_ef_gh.Slice(3));
+            }
+            {
+                var hoge = RawStringSource.Get("hoge");
+                const char separator = ' ';
+                var (a, b) = hoge.Split2(separator);
+                Assert.True(a == hoge);
+                Assert.True(hoge.Slice(4).IsEmpty);
+                Assert.True(b.IsEmpty);
+            }
+        }
+
+        [Fact]
+        public void Split2_byteSpan()
         {
             var str = RawStringSource.Get("ab, cde, efgh, ij,  ");
             ReadOnlySpan<byte> separator = stackalloc[] { (byte)',', (byte)' ' };
+
+            var tmp = str.Split2(separator);
+            Assert.True(tmp.Item1 == "ab" && tmp.Item2 == "cde, efgh, ij,  ");
+            tmp = tmp.Item2.Split2(separator);
+            Assert.True(tmp.Item1 == "cde" && tmp.Item2 == "efgh, ij,  ");
+            tmp = tmp.Item2.Split2(separator);
+            Assert.True(tmp.Item1 == "efgh" && tmp.Item2 == "ij,  ");
+            tmp = tmp.Item2.Split2(separator);
+            Assert.True(tmp.Item1 == "ij" && tmp.Item2 == " ");
+            tmp = tmp.Item2.Split2(separator);
+            Assert.True(tmp.Item1 == " " && tmp.Item2 == "");
+        }
+
+        [Fact]
+        public void Split2_string()
+        {
+            var str = RawStringSource.Get("ab, cde, efgh, ij,  ");
+            const string separator = ", ";
 
             var tmp = str.Split2(separator);
             Assert.True(tmp.Item1 == "ab" && tmp.Item2 == "cde, efgh, ij,  ");

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -415,6 +415,65 @@ namespace UnitTest
             }
         }
 
+        [Fact]
+        public void EndsWith()
+        {
+            const string str1 = "あいうえお";
+            const string str2 = "あいう";
+            const string str3 = "えお";
+            var rawStr1 = RawStringSource.Get("あいうえお");
+            var rawStr2 = RawStringSource.Get("あいう");
+            var rawStr3 = RawStringSource.Get("えお");
+
+            // [Assert true]
+            {
+                // "あいうえお" ends with "あいうえお"
+                Assert.True(rawStr1.EndsWith(rawStr1));                     // RawString -- RawString
+                Assert.True(rawStr1.EndsWith(rawStr1.AsSpan()));            // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.EndsWith(str1));                        // RawString -- string
+                Assert.True(rawStr1.EndsWith(str1.AsSpan()));               // RawString -- ReadOnlySpan<char>
+
+                // "あいうえお" ends with "えお"
+                Assert.True(rawStr1.EndsWith(rawStr3));                     // RawString -- RawString
+                Assert.True(rawStr1.EndsWith(rawStr3.AsSpan()));            // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.EndsWith(str3));                        // RawString -- string
+                Assert.True(rawStr1.EndsWith(str3.AsSpan()));               // RawString -- ReadOnlySpan<char>
+
+                // "あいうえお" ends with ""
+                Assert.True(rawStr1.EndsWith(RawString.Empty));             // RawString -- RawString
+                Assert.True(rawStr1.EndsWith(ReadOnlySpan<byte>.Empty));    // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.EndsWith(string.Empty));                // RawString -- string
+                Assert.True(rawStr1.EndsWith(ReadOnlySpan<char>.Empty));    // RawString -- ReadOnlySpan<char>
+
+                // "あいう" ends with "あいう"
+                Assert.True(rawStr2.EndsWith(rawStr2));                     // RawString -- RawString
+                Assert.True(rawStr2.EndsWith(rawStr2.AsSpan()));            // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.EndsWith(str2));                        // RawString -- string
+                Assert.True(rawStr2.EndsWith(str2.AsSpan()));               // RawString -- ReadOnlySpan<char>
+
+                // "あいう" ends with ""
+                Assert.True(rawStr2.EndsWith(RawString.Empty));             // RawString -- RawString
+                Assert.True(rawStr2.EndsWith(ReadOnlySpan<byte>.Empty));    // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.EndsWith(string.Empty));                // RawString -- string
+                Assert.True(rawStr2.EndsWith(ReadOnlySpan<char>.Empty));    // RawString -- ReadOnlySpan<char>
+            }
+
+            // [Assert false]
+            {
+                // "あいうえお" does not end with "あいう"
+                Assert.False(rawStr1.EndsWith(rawStr2));                    // RawString -- RawString
+                Assert.False(rawStr1.EndsWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr1.EndsWith(str2));                       // RawString -- string
+                Assert.False(rawStr1.EndsWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
+
+                // "あいう" does not end with "えお"
+                Assert.False(rawStr2.EndsWith(rawStr3));                    // RawString -- RawString
+                Assert.False(rawStr2.EndsWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr2.EndsWith(str3));                       // RawString -- string
+                Assert.False(rawStr2.EndsWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
+            }
+        }
+
         private readonly struct Check<T>
         {
             public readonly T Answer;

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -356,6 +356,65 @@ namespace UnitTest
             }
         }
 
+        [Fact]
+        public void StartWith()
+        {
+            const string str1 = "あいうえお";
+            const string str2 = "あいう";
+            const string str3 = "えお";
+            var rawStr1 = RawStringSource.Get("あいうえお");
+            var rawStr2 = RawStringSource.Get("あいう");
+            var rawStr3 = RawStringSource.Get("えお");
+
+            // [Assert true]
+            {
+                // "あいうえお" starts with "あいうえお"
+                Assert.True(rawStr1.StartWith(rawStr1));                    // RawString -- RawString
+                Assert.True(rawStr1.StartWith(rawStr1.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartWith(str1));                       // RawString -- string
+                Assert.True(rawStr1.StartWith(str1.AsSpan()));              // RawString -- ReadOnlySpan<char>
+
+                // "あいうえお" starts with "あいう"
+                Assert.True(rawStr1.StartWith(rawStr2));                    // RawString -- RawString
+                Assert.True(rawStr1.StartWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartWith(str2));                       // RawString -- string
+                Assert.True(rawStr1.StartWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
+
+                // "あいうえお" starts with ""
+                Assert.True(rawStr1.StartWith(RawString.Empty));            // RawString -- RawString
+                Assert.True(rawStr1.StartWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr1.StartWith(string.Empty));               // RawString -- string
+                Assert.True(rawStr1.StartWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
+
+                // "あいう" starts with "あいう"
+                Assert.True(rawStr2.StartWith(rawStr2));                    // RawString -- RawString
+                Assert.True(rawStr2.StartWith(rawStr2.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.StartWith(str2));                       // RawString -- string
+                Assert.True(rawStr2.StartWith(str2.AsSpan()));              // RawString -- ReadOnlySpan<char>
+
+                // "あいう" starts with ""
+                Assert.True(rawStr2.StartWith(RawString.Empty));            // RawString -- RawString
+                Assert.True(rawStr2.StartWith(ReadOnlySpan<byte>.Empty));   // RawString -- ReadOnlySpan<byte>
+                Assert.True(rawStr2.StartWith(string.Empty));               // RawString -- string
+                Assert.True(rawStr2.StartWith(ReadOnlySpan<char>.Empty));   // RawString -- ReadOnlySpan<char>
+            }
+
+            // [Assert false]
+            {
+                // "あいうえお" does not start with "えお"
+                Assert.False(rawStr1.StartWith(rawStr3));                    // RawString -- RawString
+                Assert.False(rawStr1.StartWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr1.StartWith(str3));                       // RawString -- string
+                Assert.False(rawStr1.StartWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
+
+                // "あいう" starts with "えお"
+                Assert.False(rawStr2.StartWith(rawStr3));                    // RawString -- RawString
+                Assert.False(rawStr2.StartWith(rawStr3.AsSpan()));           // RawString -- ReadOnlySpan<byte>
+                Assert.False(rawStr2.StartWith(str3));                       // RawString -- string
+                Assert.False(rawStr2.StartWith(str3.AsSpan()));              // RawString -- ReadOnlySpan<char>
+            }
+        }
+
         private readonly struct Check<T>
         {
             public readonly T Answer;
@@ -462,6 +521,10 @@ namespace UnitTest
         private static partial ReadOnlySpan<byte> Str44();
         [Utf8("17E+307")]
         private static partial ReadOnlySpan<byte> Str45();
+        [Utf8("あいう")]
+        private static partial ReadOnlySpan<byte> Str46();
+        [Utf8("えお")]
+        private static partial ReadOnlySpan<byte> Str47();
 
         static RawStringSource()
         {
@@ -511,6 +574,8 @@ namespace UnitTest
             Register(Str43());
             Register(Str44());
             Register(Str45());
+            Register(Str46());
+            Register(Str47());
 
             static unsafe void Register(ReadOnlySpan<byte> s)
             {


### PR DESCRIPTION
# Add API

## Summary

- Methods for finding a node or an attribute by name. 
- Overloads for `string` and `ReadOnlySpan<char>` of methods whose argument is `RawString` or `ReadOnlySpan<byte>`.
- APIs for enumeration of descendent nodes
- etc...

## Added

### Methods and Properties

- in `struct U8Xml.RawString`
  - `IntPtr Ptr { get; }`
  - `bool StartsWith(ReadOnlySpan<byte>)`
  - `bool StartsWith(RawString)`
  - `bool StartsWith(ReadOnlySpan<char>)`
  - `bool StartsWith(string)`
  - `bool EndsWith(ReadOnlySpan<byte>)`
  - `bool EndsWith(RawString)`
  - `bool EndsWith(ReadOnlySpan<char>)`
  - `bool EndsWith(string)`
  - `bool RawString == ReadOnlySpan<byte>`, `RawString != ReadOnlySpan<byte>`
  - `bool ReadOnlySpan<byte> == RawString`, `ReadOnlySpan<byte> != RawString`
  - `bool RawString == ReadOnlySpan<char>`, `RawString != ReadOnlySpan<char>`
  - `bool ReadOnlySpan<char> == RawString`, `ReadOnlySpan<char> != RawString`

- in `struct U8Xml.AllNodeList`
  - `XmlNode First()`
  - `XmlNode First(Func<XmlNode, bool>)`
  - `Option<XmlNode> FirstOrDefault()`
  - `Option<XmlNode> FirstOrDefault(Func<XmlNode, bool>)`

- in `struct U8Xml.XmlNode`
  - `XmlNodeDescendantList Descendants { get; }`
  - `int Depth { get; }`
  - `Option<XmlNode> FindChildOrDefault(RawString)`
  - `Option<XmlNode> FindChildOrDefault(ReadOnlySpan<byte>)`
  - `Option<XmlNode> FindChildOrDefault(string)`
  - `Option<XmlNode> FindChildOrDefault(ReadOnlySpan<char>)`
  - `XmlNode FindChild(RawString)`
  - `XmlNode FindChild(ReadOnlySpan<byte>)`
  - `XmlNode FindChild(string)`
  - `XmlNode FindChild(ReadOnlySpan<char>)`
  - `bool TryFindChild(RawString, out XmlNode)`
  - `bool TryFindChild(ReadOnlySpan<byte>, out XmlNode)`
  - `bool TryFindChild(string, out XmlNode)`
  - `bool TryFindChild(ReadOnlySpan<char>, out XmlNode)`
  - `Option<XmlAttribute> FindAttributeOrDefault(RawString)`
  - `Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<byte>)`
  - `Option<XmlAttribute> FindAttributeOrDefault(string)`
  - `Option<XmlAttribute> FindAttributeOrDefault(ReadOnlySpan<char>)`
  - `XmlAttribute FindAttribute(RawString)`
  - `XmlAttribute FindAttribute(ReadOnlySpan<byte>)`
  - `XmlAttribute FindAttribute(string)`
  - `XmlAttribute FindAttribute(ReadOnlySpan<char>)`
  - `bool TryFindAttribute(RawString, out XmlAttribute)`
  - `bool TryFindAttribute(ReadOnlySpan<byte>, out XmlAttribute)`
  - `bool TryFindAttribute(string, out XmlAttribute)`
  - `bool TryFindAttribute(ReadOnlySpan<char>, out XmlAttribute)`
  - `bool TryGetParent(out XmlNode)`
  - `bool TryGetFirstChild(out XmlNode)`
  - `bool TryGetLastChild(out XmlNode)`
  - `bool TryGetNestSibling(out XmlNode)`

- in `struct U8Xml.RawString`
  - `(RawString, RawString) Split2(ReadOnlySpan<byte>)`
  - `(RawString, RawString) Split2(char)`
  - `(RawString, RawString) Split2(string)`
  - `(RawString, RawString) Split2(ReadOnlySpan<char>)`
  - `SplitRawStrings Split(byte)`
  - `SplitRawStrings Split(ReadOnlySpan<byte>)`
  - `static int GetHashCode(ReadOnlySpan<byte>)`
  - `static int GetHashCode(IntPtr, int)`

- in `struct U8Xml.Option<T>`
  - `static Option<T> Null { get; }`

### Types

- `struct U8Xml.XmlNodeDescendantList`
- `class U8Xml.XmlNodeEnumerableExtension`
- `class U8Xml.XmlAttributeEnumerableExtension`
- `struct U8Xml.SplitRawStrings`

## Changed into deprecated

`StartWith` methods are change into `Start**s**With`, so `StartWith` got obsolete.

- in `struct U8Xml.RawString`
  - `bool StartWith(ReadOnlySpan<byte>)`
  - `bool StartWith(RawString)`
