### PR TITLE
Add APIs for getting full name of a node and an attribute.

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
@@ -116,6 +116,35 @@ namespace U8Xml
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsName(string namespaceName, string name) => IsName(namespaceName.AsSpan(), name.AsSpan());
 
+        /// <summary>Get full name of the attribute. Returns false if the full name could not be resolved.</summary>
+        /// <param name="namespaceName">
+        /// namespace name of the attribute<para/>
+        /// ex) "abcde" in the case the attribute is a:bar="123" in &lt;node xmlns:a="abcde" a:bar="123" /&gt;<para/>
+        /// </param>
+        /// <param name="name">
+        /// local name of the attribute<para/>
+        /// ex) "bar" in the case the attribute is a:bar="123" in &lt;node xmlns:a="abcde" a:bar="123" /&gt;<para/>
+        /// </param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetFullName(out RawString namespaceName, out RawString name) => XmlnsHelper.TryGetAttributeFullName(this, out namespaceName, out name);
+
+        /// <summary>Get full name of the attribute. The method throws <see cref="InvalidOperationException"/> if the full name could not resolved.</summary>
+        /// <remarks>
+        /// ex) Returns ("abcde", "bar") in the case the attribute is a:bar="123" in &lt;node xmlns:a="abcde" a:bar="123" /&gt;<para/>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">the full name could not resolved</exception>
+        /// <returns>A pair of namespace name and local name</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (RawString NamespaceName, RawString Name) GetFullName()
+        {
+            if(XmlnsHelper.TryGetAttributeFullName(this, out var namespaceName, out var name) == false) {
+                ThrowNoNamespace();
+                static void ThrowNoNamespace() => throw new InvalidOperationException("Could not resolve the full name of the node.");
+            }
+            return (namespaceName, name);
+        }
+
         public override bool Equals(object? obj) => obj is XmlAttribute attribute && Equals(attribute);
 
         public bool Equals(XmlAttribute other) => _attr == other._attr;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -369,6 +369,35 @@ namespace U8Xml
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryFindAttribute(string namespaceName, string name, out XmlAttribute attribute) => Attributes.TryFind(namespaceName, name, out attribute);
 
+        /// <summary>Get full name of the node. Returns false if the full name could not be resolved.</summary>
+        /// <param name="namespaceName">
+        /// namespace name of the node<para/>
+        /// ex) "abcde" in the case the node is &lt;a:foo xmlns:a="abcde" /&gt;<para/>
+        /// </param>
+        /// <param name="name">
+        /// local name of the node<para/>
+        /// ex) "foo" in the case the node is &lt;a:foo xmlns:a="abcde" /&gt;<para/>
+        /// </param>
+        /// <returns>Whether the full name of the node could be resolved</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetFullName(out RawString namespaceName, out RawString name) => XmlnsHelper.TryGetNodeFullName(this, out namespaceName, out name);
+
+        /// <summary>Get full name of the node. The method throws <see cref="InvalidOperationException"/> if the full name could not resolved.</summary>
+        /// <remarks>
+        /// ex) Returns ("abcde", "foo") in the case the node is &lt;a:foo xmlns:a="abcde" /&gt;<para/>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">the full name could not resolved</exception>
+        /// <returns>A pair of namespace name and local name</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (RawString NamespaceName, RawString Name) GetFullName()
+        {
+            if(XmlnsHelper.TryGetNodeFullName(this, out var namespaceName, out var name) == false) {
+                ThrowNoNamespace();
+                static void ThrowNoNamespace() => throw new InvalidOperationException("Could not resolve the full name of the node.");
+            }
+            return (namespaceName, name);
+        }
+
         /// <inheritdoc/>
         public override bool Equals(object? obj) => obj is XmlNode node && Equals(node);
 

--- a/src/UnitTest/FindAttributeTest.cs
+++ b/src/UnitTest/FindAttributeTest.cs
@@ -55,6 +55,17 @@ namespace UnitTest
                     attr.IsName(nsName_ROSbyte, name_RS).ShouldBe(true);
                     attr.IsName(nsName_RS, name_RS).ShouldBe(true);
                 }
+
+                {
+                    attr.TryGetFullName(out var nsNameResolved, out var nameResolved).ShouldBe(true);
+                    (nsNameResolved == nsName).ShouldBe(true);
+                    (nameResolved == name).ShouldBe(true);
+                }
+                {
+                    var (nsNameResolved, nameResolved) = attr.GetFullName();
+                    (nsNameResolved == nsName).ShouldBe(true);
+                    (nameResolved == name).ShouldBe(true);
+                }
             }
         }
 

--- a/src/UnitTest/FindChildTest.cs
+++ b/src/UnitTest/FindChildTest.cs
@@ -55,6 +55,17 @@ namespace UnitTest
                     node.IsName(nsName_ROSbyte, name_RS).ShouldBe(true);
                     node.IsName(nsName_RS, name_RS).ShouldBe(true);
                 }
+
+                {
+                    node.TryGetFullName(out var nsNameResolved, out var nameResolved).ShouldBe(true);
+                    (nsNameResolved == nsName).ShouldBe(true);
+                    (nameResolved == name).ShouldBe(true);
+                }
+                {
+                    var (nsNameResolved, nameResolved) = node.GetFullName();
+                    (nsNameResolved == nsName).ShouldBe(true);
+                    (nameResolved == name).ShouldBe(true);
+                }
             }
         }
 


### PR DESCRIPTION
# Add APIs for getting full name of a node and an attribute

## Added

- in `struct U8Xml.XmlNode`

  - `bool TryGetFullName(out RawString, out RawString)`
  - `(RawString, RawString) GetFullName()`

- in `struct U8Xml.XmlAttribute`

  - `bool TryGetFullName(out RawString, out RawString)`
  - `(RawString, RawString) GetFullName()`
