### PR TITLE
Throw exception for raw string surrogate comparison

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/SpanHelper.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/SpanHelper.cs
@@ -27,9 +27,9 @@ namespace U8Xml.Internal
         public static string Utf8ToString(this ReadOnlySpan<byte> source)
         {
 #if NO_SPAN_API
-            unsafe { fixed(byte* ptr = source) { return Encoding.UTF8.GetString(ptr, source.Length); } }
+            unsafe { fixed(byte* ptr = source) { return UTF8ExceptionFallbackEncoding.Instance.GetString(ptr, source.Length); } }
 #else
-            return Encoding.UTF8.GetString(source);
+            return UTF8ExceptionFallbackEncoding.Instance.GetString(source);
 #endif
         }
 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/UTF8ExceptionFallbackEncoding.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/UTF8ExceptionFallbackEncoding.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using System.Text;
+
+namespace U8Xml.Internal
+{
+    internal sealed class UTF8ExceptionFallbackEncoding : UTF8Encoding
+    {
+        public static UTF8ExceptionFallbackEncoding Instance { get; } = new UTF8ExceptionFallbackEncoding();
+        private UTF8ExceptionFallbackEncoding() : base(false, true) { }
+    }
+}

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/UTF8ExceptionFallbackEncoding.cs.meta
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/Internal/UTF8ExceptionFallbackEncoding.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a46b099fe6a83a49905a532b2fa91a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.Conversion.cs
@@ -267,7 +267,7 @@ namespace U8Xml
             else {
                 const int CharMaxByteCount = 6;
                 byte* buf = stackalloc byte[CharMaxByteCount];
-                var byteCount = Encoding.UTF8.GetBytes(&separator, 1, buf, CharMaxByteCount);
+                var byteCount = UTF8ExceptionFallbackEncoding.Instance.GetBytes(&separator, 1, buf, CharMaxByteCount);
                 return Split2(SpanHelper.CreateReadOnlySpan<byte>(buf, byteCount));
             }
         }
@@ -287,12 +287,12 @@ namespace U8Xml
             if(separator.Length <= ThresholdLen) {
                 byte* buf = stackalloc byte[StackBufSize];
                 fixed(char* ptr = separator) {
-                    var byteCount = Encoding.UTF8.GetBytes(ptr, separator.Length, buf, StackBufSize);
+                    var byteCount = UTF8ExceptionFallbackEncoding.Instance.GetBytes(ptr, separator.Length, buf, StackBufSize);
                     return Split2(SpanHelper.CreateReadOnlySpan<byte>(buf, byteCount));
                 }
             }
             else {
-                var utf8 = Encoding.UTF8;
+                var utf8 = UTF8ExceptionFallbackEncoding.Instance;
                 var byteCount = utf8.GetByteCount(separator);
                 var buf = ArrayPool<byte>.Shared.Rent(byteCount);
                 try {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/RawString.cs
@@ -156,7 +156,7 @@ namespace U8Xml
 
         /// <summary>Decode byte array as utf-8 and get <see langword="string"/></summary>
         /// <returns>decoded string</returns>
-        public override string ToString() => IsEmpty ? "" : Encoding.UTF8.GetString((byte*)_ptr, _length);
+        public override string ToString() => IsEmpty ? "" : UTF8ExceptionFallbackEncoding.Instance.GetString((byte*)_ptr, _length);
 
         public override bool Equals(object? obj) => obj is RawString array && Equals(array);
 
@@ -184,7 +184,7 @@ namespace U8Xml
             if(other.Length == 0) {
                 return true;
             }
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var byteLen = utf8.GetByteCount(other);
             if(byteLen > Length) {
                 return false;
@@ -236,7 +236,7 @@ namespace U8Xml
             if(other.Length == 0) {
                 return true;
             }
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var byteLen = utf8.GetByteCount(other);
             if(byteLen > Length) {
                 return false;
@@ -318,7 +318,7 @@ namespace U8Xml
         public static bool operator ==(RawString left, ReadOnlySpan<char> right)
         {
             if(right.IsEmpty) { return left.IsEmpty; }
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var byteLen = utf8.GetByteCount(right);
             if(byteLen != left.Length) { return false; }
 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttribute.cs
@@ -72,7 +72,7 @@ namespace U8Xml
                 return false;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var nsNameByteLen = utf8.GetByteCount(namespaceName);
             var nameByteLen = utf8.GetByteCount(name);
             var byteLen = nsNameByteLen + nameByteLen;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlAttributeEnumerableExtension.cs
@@ -117,7 +117,7 @@ namespace U8Xml
                 return Option<XmlAttribute>.Null;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var byteLen = utf8.GetByteCount(name);
 
             const int Threshold = 128;
@@ -162,7 +162,7 @@ namespace U8Xml
                 return Option<XmlAttribute>.Null;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var nsNameByteLen = utf8.GetByteCount(namespaceName);
             var nameByteLen = utf8.GetByteCount(name);
             var byteLen = nsNameByteLen + nameByteLen;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlEntityTable.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlEntityTable.cs
@@ -145,7 +145,7 @@ namespace U8Xml
                 Span<byte> buf = stackalloc byte[Threshold];
                 Resolve(str, buf);
                 fixed(byte* ptr = buf) {
-                    return Encoding.UTF8.GetString(ptr, byteLen);
+                    return UTF8ExceptionFallbackEncoding.Instance.GetString(ptr, byteLen);
                 }
             }
             else {
@@ -153,7 +153,7 @@ namespace U8Xml
                 try {
                     Resolve(str, buf.AsSpan());
                     fixed(byte* ptr = buf) {
-                        return Encoding.UTF8.GetString(ptr, byteLen);
+                        return UTF8ExceptionFallbackEncoding.Instance.GetString(ptr, byteLen);
                     }
                 }
                 finally {

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -104,7 +104,7 @@ namespace U8Xml
                 return false;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var nsNameByteLen = utf8.GetByteCount(namespaceName);
             var nameByteLen = utf8.GetByteCount(name);
             var byteLen = nsNameByteLen + nameByteLen;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNodeEnumerableExtension.cs
@@ -47,7 +47,7 @@ namespace U8Xml
                 return Option<XmlNode>.Null;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var byteLen = utf8.GetByteCount(name);
 
             const int Threshold = 128;
@@ -126,7 +126,7 @@ namespace U8Xml
                 return Option<XmlNode>.Null;
             }
 
-            var utf8 = Encoding.UTF8;
+            var utf8 = UTF8ExceptionFallbackEncoding.Instance;
             var nsNameByteLen = utf8.GetByteCount(namespaceName);
             var nameByteLen = utf8.GetByteCount(name);
             var byteLen = nsNameByteLen + nameByteLen;

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
@@ -30,9 +30,9 @@ namespace U8Xml
             var buf = default(UnmanagedBuffer);
             try {
                 fixed(char* ptr = text) {
-                    var byteLen = Encoding.UTF8.GetByteCount(ptr, text.Length);
+                    var byteLen = UTF8ExceptionFallbackEncoding.Instance.GetByteCount(ptr, text.Length);
                     buf = new UnmanagedBuffer(byteLen);
-                    Encoding.UTF8.GetBytes(ptr, text.Length, (byte*)buf.Ptr, buf.Length);
+                    UTF8ExceptionFallbackEncoding.Instance.GetBytes(ptr, text.Length, (byte*)buf.Ptr, buf.Length);
                 }
                 return new XmlObject(ParseCore(ref buf, buf.Length));
             }

--- a/src/UnitTest/FindAttributeTest.cs
+++ b/src/UnitTest/FindAttributeTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Text;
 using U8Xml;
+using U8Xml.Internal;
 using Xunit;
 
 namespace UnitTest
@@ -43,8 +44,8 @@ namespace UnitTest
                 attr.IsName(nsName.AsSpan(), name.AsSpan()).ShouldBe(true);
                 attr.IsName(nsName, name.AsSpan()).ShouldBe(true);
 
-                var nsName_ROSbyte = Encoding.UTF8.GetBytes(nsName).AsSpan();
-                var name_ROSbyte = Encoding.UTF8.GetBytes(name).AsSpan();
+                var nsName_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(nsName).AsSpan();
+                var name_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(name).AsSpan();
                 fixed(byte* p = nsName_ROSbyte)
                 fixed(byte* p2 = name_ROSbyte) {
                     var nsName_RS = new RawString(p, nsName_ROSbyte.Length);
@@ -152,7 +153,7 @@ namespace UnitTest
             target.Attributes.Find(name!).Value.ToInt32().ShouldBe(value);
             target.Attributes.Find(name.AsSpan()).Value.ToInt32().ShouldBe(value);
 
-            var name_ROSbyte = Encoding.UTF8.GetBytes(name ?? "");
+            var name_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(name ?? "");
             fixed(byte* p = name_ROSbyte) {
                 var name_RS = new RawString(p, name_ROSbyte.Length);
 
@@ -218,7 +219,7 @@ namespace UnitTest
                 attr.Value.ToInt32().ShouldBe(value);
             }
 
-            var name_ROSbyte = Encoding.UTF8.GetBytes(name ?? "");
+            var name_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(name ?? "");
             fixed(byte* p = name_ROSbyte) {
                 fixed(byte* p2 = name_ROSbyte) {
                     var name_RS = new RawString(p, name_ROSbyte.Length);
@@ -368,7 +369,7 @@ namespace UnitTest
             target.Attributes.FindOrDefault(name!).Value.Value.ToInt32().ShouldBe(value);
             target.Attributes.FindOrDefault(name.AsSpan()).Value.Value.ToInt32().ShouldBe(value);
 
-            var name_ROSbyte = Encoding.UTF8.GetBytes(name ?? "");
+            var name_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(name ?? "");
             fixed(byte* p = name_ROSbyte) {
                 var name_RS = new RawString(p, name_ROSbyte.Length);
 
@@ -488,9 +489,9 @@ namespace UnitTest
             public string? Name { get; }
 
             public ReadOnlySpan<char> NsName_ROSchar => NsName.AsSpan();
-            public ReadOnlySpan<byte> NsName_ROSbyte => Encoding.UTF8.GetBytes(NsName?.ToCharArray() ?? Array.Empty<char>());
+            public ReadOnlySpan<byte> NsName_ROSbyte => UTF8ExceptionFallbackEncoding.Instance.GetBytes(NsName?.ToCharArray() ?? Array.Empty<char>());
             public ReadOnlySpan<char> Name_ROSchar => Name.AsSpan();
-            public ReadOnlySpan<byte> Name_ROSbyte => Encoding.UTF8.GetBytes(Name?.ToCharArray() ?? Array.Empty<char>());
+            public ReadOnlySpan<byte> Name_ROSbyte => UTF8ExceptionFallbackEncoding.Instance.GetBytes(Name?.ToCharArray() ?? Array.Empty<char>());
 
             public AttrName(string? nsName, string? name)
             {

--- a/src/UnitTest/FindChildTest.cs
+++ b/src/UnitTest/FindChildTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Text;
 using U8Xml;
+using U8Xml.Internal;
 using Xunit;
 
 namespace UnitTest
@@ -43,8 +44,8 @@ namespace UnitTest
                 node.IsName(nsName.AsSpan(), name.AsSpan()).ShouldBe(true);
                 node.IsName(nsName, name.AsSpan()).ShouldBe(true);
 
-                var nsName_ROSbyte = Encoding.UTF8.GetBytes(nsName).AsSpan();
-                var name_ROSbyte = Encoding.UTF8.GetBytes(name).AsSpan();
+                var nsName_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(nsName).AsSpan();
+                var name_ROSbyte = UTF8ExceptionFallbackEncoding.Instance.GetBytes(name).AsSpan();
                 fixed(byte* p = nsName_ROSbyte)
                 fixed(byte* p2 = name_ROSbyte) {
                     var nsName_RS = new RawString(p, nsName_ROSbyte.Length);
@@ -443,9 +444,9 @@ namespace UnitTest
             public string? Name { get; }
 
             public ReadOnlySpan<char> NsName_ROSchar => NsName.AsSpan();
-            public ReadOnlySpan<byte> NsName_ROSbyte => Encoding.UTF8.GetBytes(NsName?.ToCharArray() ?? Array.Empty<char>());
+            public ReadOnlySpan<byte> NsName_ROSbyte => UTF8ExceptionFallbackEncoding.Instance.GetBytes(NsName?.ToCharArray() ?? Array.Empty<char>());
             public ReadOnlySpan<char> Name_ROSchar => Name.AsSpan();
-            public ReadOnlySpan<byte> Name_ROSbyte => Encoding.UTF8.GetBytes(Name?.ToCharArray() ?? Array.Empty<char>());
+            public ReadOnlySpan<byte> Name_ROSbyte => UTF8ExceptionFallbackEncoding.Instance.GetBytes(Name?.ToCharArray() ?? Array.Empty<char>());
 
             public NodeName(string? nsName, string? name)
             {

--- a/src/UnitTest/ParserTest.cs
+++ b/src/UnitTest/ParserTest.cs
@@ -214,7 +214,7 @@ namespace UnitTest
                     var buf = new byte[len];
                     Assert.True(entities.Resolve(attr.Value, buf) == len);
                     Assert.True(buf.SequenceEqual(resolved));
-                    Assert.True(Encoding.UTF8.GetString(resolved) == "123ふー456∑∑");
+                    Assert.True(UTF8ExceptionFallbackEncoding.Instance.GetString(resolved) == "123ふー456∑∑");
                     Assert.True(entities.ResolveToString(attr.Value) == "123ふー456∑∑");
                 }
             }
@@ -251,7 +251,7 @@ namespace UnitTest
                             var buf = new byte[len];
                             Assert.True(entities.Resolve(attr.Value, buf) == len);
                             Assert.True(buf.SequenceEqual(resolved));
-                            Assert.True(Encoding.UTF8.GetString(resolved) == "123ふー456∑∑");
+                            Assert.True(UTF8ExceptionFallbackEncoding.Instance.GetString(resolved) == "123ふー456∑∑");
                             Assert.True(entities.ResolveToString(attr.Value) == "123ふー456∑∑");
                         }
                     }

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Linq;
+using U8Xml.Internal;
 
 namespace UnitTest
 {
@@ -603,11 +604,11 @@ namespace UnitTest
             const string FallbackCharStr = "\ufffd";
             // "\ud83d" is one of the surrogate
             const string SurrogateCharStr = "\ud83d";
-            var fallbackCharUtf8Bytes = Encoding.UTF8.GetBytes(FallbackCharStr);
+            var fallbackCharUtf8Bytes = UTF8ExceptionFallbackEncoding.Instance.GetBytes(FallbackCharStr);
             fixed(byte* ptr = fallbackCharUtf8Bytes) {
                 var fallbackCharRawStr = new RawString(ptr, fallbackCharUtf8Bytes.Length);
-                Assert.False(fallbackCharRawStr.StartsWith(SurrogateCharStr));
-                Assert.False(fallbackCharRawStr.EndsWith(SurrogateCharStr));
+                Assert.Throws<EncoderFallbackException>(() => fallbackCharRawStr.StartsWith(SurrogateCharStr));
+                Assert.Throws<EncoderFallbackException>(() => fallbackCharRawStr.EndsWith(SurrogateCharStr));
             }
         }
 
@@ -779,7 +780,7 @@ namespace UnitTest
             static unsafe void Register(ReadOnlySpan<byte> s)
             {
                 var ptr = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(s));
-                var str = Encoding.UTF8.GetString(s.ToArray());
+                var str = UTF8ExceptionFallbackEncoding.Instance.GetString(s.ToArray());
                 _dic[str] = new RawString(ptr, s.Length);
             }
         }

--- a/src/UnitTest/RawStringTest.cs
+++ b/src/UnitTest/RawStringTest.cs
@@ -596,6 +596,21 @@ namespace UnitTest
             Assert.True(rawStr3.GetHashCode() == RawString.GetHashCode(rawStr3.Ptr, rawStr3.Length));
         }
 
+        [Fact]
+        public unsafe void UnpairedSurrogateComparison()
+        {
+            // "\ufffd" == "�" It is the default fallback character for UTF8Encoding
+            const string FallbackCharStr = "\ufffd";
+            // "\ud83d" is one of the surrogate
+            const string SurrogateCharStr = "\ud83d";
+            var fallbackCharUtf8Bytes = Encoding.UTF8.GetBytes(FallbackCharStr);
+            fixed(byte* ptr = fallbackCharUtf8Bytes) {
+                var fallbackCharRawStr = new RawString(ptr, fallbackCharUtf8Bytes.Length);
+                Assert.False(fallbackCharRawStr.StartsWith(SurrogateCharStr));
+                Assert.False(fallbackCharRawStr.EndsWith(SurrogateCharStr));
+            }
+        }
+
         private readonly struct Check<T>
         {
             public readonly T Answer;

--- a/src/UnitTest/TestCases.cs
+++ b/src/UnitTest/TestCases.cs
@@ -6,6 +6,7 @@ using U8Xml;
 using U8Xml.Unsafes;
 using System.Text;
 using System.Collections.Generic;
+using U8Xml.Internal;
 
 namespace UnitTest
 {
@@ -19,9 +20,9 @@ namespace UnitTest
                 // from ReadOnlySpan<byte>
                 () => XmlParser.Parse(xmlBytes.ToArray()),
                 // from string
-                () => XmlParser.Parse(Encoding.UTF8.GetString(xmlBytes.ToArray())),
+                () => XmlParser.Parse(UTF8ExceptionFallbackEncoding.Instance.GetString(xmlBytes.ToArray())),
                 // from ReadOnlySpan<char>
-                () => XmlParser.Parse(Encoding.UTF8.GetString(xmlBytes.ToArray()).AsSpan()),
+                () => XmlParser.Parse(UTF8ExceptionFallbackEncoding.Instance.GetString(xmlBytes.ToArray()).AsSpan()),
                 // from Stream
                 () => XmlParser.Parse(new MemoryStream(xmlBytes.ToArray())),
                 // from Stream, fileSizeHint
@@ -31,7 +32,7 @@ namespace UnitTest
                     return XmlParser.Parse(ms, (int)ms.Length);
                 },
                 // from Stream, Encoding
-                ReEncoding(xmlBytes.ToArray(), Encoding.UTF8),
+                ReEncoding(xmlBytes.ToArray(), UTF8ExceptionFallbackEncoding.Instance),
                 ReEncoding(xmlBytes.ToArray(), Encoding.Unicode),
                 ReEncoding(xmlBytes.ToArray(), Encoding.BigEndianUnicode),
                 ReEncoding(xmlBytes.ToArray(), Encoding.UTF32),
@@ -58,7 +59,7 @@ namespace UnitTest
 
         private static Func<XmlObject> ReEncoding(ReadOnlySpan<byte> xml, Encoding encoding)
         {
-            var bytes = Encoding.Convert(Encoding.UTF8, encoding, xml.ToArray());
+            var bytes = Encoding.Convert(UTF8ExceptionFallbackEncoding.Instance, encoding, xml.ToArray());
             var ms = new MemoryStream(bytes);
             return () => XmlParser.Parse(ms, encoding);
         }


### PR DESCRIPTION
This fixes #10 by throwing `EncoderFallbackException` for arguments containing unpaired surrogates.

This will also works as devirtualization for methods in `Encoding.UTF8`.