### PR TITLE
Add a method for getting xml node as RawString.

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -61,6 +61,9 @@ namespace U8Xml
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal XmlNode(XmlNode_* node) => _node = (IntPtr)node;
 
+        /// <summary>Get the string that this node represents as <see cref="RawString"/>.</summary>
+        /// <remarks>The indent of the node is ignored at the head.</remarks>
+        /// <returns><see cref="RawString"/> this node represents</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public RawString AsRawString() => ((XmlNode_*)_node)->AsRawString();
 

--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlNode.cs
@@ -62,6 +62,9 @@ namespace U8Xml
         internal XmlNode(XmlNode_* node) => _node = (IntPtr)node;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RawString AsRawString() => ((XmlNode_*)_node)->AsRawString();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetParent(out XmlNode parent) => Parent.TryGetValue(out parent);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetFirstChild(out XmlNode firstChild) => FirstChild.TryGetValue(out firstChild);
@@ -433,6 +436,8 @@ namespace U8Xml
         public readonly int Depth;
         public readonly RawString Name;
         public RawString InnerText;
+        public readonly byte* NodeStrPtr;
+        public int NodeStrLength;
 
         public XmlNode_* Parent;
         public XmlNode_* FirstChild;
@@ -457,7 +462,7 @@ namespace U8Xml
         public bool HasChildren => FirstChild != null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal XmlNode_(CustomList<XmlNode_> wholeNodes, int nodeIndex, int depth, RawString name, CustomList<XmlAttribute_> wholeAttrs)
+        internal XmlNode_(CustomList<XmlNode_> wholeNodes, int nodeIndex, int depth, RawString name, byte* nodeStrPtr, CustomList<XmlAttribute_> wholeAttrs)
         {
             // [NOTE]
             // _wholeNodes is CustomList<XmlNode_>,
@@ -480,8 +485,13 @@ namespace U8Xml
             AttrIndex = 0;
             AttrCount = 0;
             WholeAttrs = wholeAttrs;
+            NodeStrPtr = nodeStrPtr;
+            NodeStrLength = 0;
             HasXmlNamespaceAttr = false;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RawString AsRawString() => new RawString(NodeStrPtr, NodeStrLength);
 
         public override string ToString()
         {

--- a/src/UnitTest/NodeStringTest.cs
+++ b/src/UnitTest/NodeStringTest.cs
@@ -1,0 +1,59 @@
+﻿#nullable enable
+using Xunit;
+using U8Xml;
+
+namespace UnitTest
+{
+    public class NodeStringTest
+    {
+        [Fact]
+        public void NodeAsString()
+        {
+            const string XmlString =
+@"<?xml version='1.0' ?>
+<root>
+  <foo>
+    <bar1 id='1'/>
+    <bar2 id='2'>
+        <baz>abc</baz>
+    </bar2>
+  </foo>
+</root>";
+
+            using var xml = XmlParser.Parse(XmlString);
+            Assert.True(xml.AsRawString() == XmlString);
+
+            var root = xml.Root;
+            Assert.True(root.AsRawString() ==
+@"<root>
+  <foo>
+    <bar1 id='1'/>
+    <bar2 id='2'>
+        <baz>abc</baz>
+    </bar2>
+  </foo>
+</root>");
+
+            var foo = xml.Root.FindChild("foo");
+            Assert.True(foo.AsRawString() ==
+@"<foo>
+    <bar1 id='1'/>
+    <bar2 id='2'>
+        <baz>abc</baz>
+    </bar2>
+  </foo>");
+
+            var bar1 = foo.FindChild("bar1");
+            Assert.True(bar1.AsRawString() == @"<bar1 id='1'/>");
+
+            var bar2 = foo.FindChild("bar2");
+            Assert.True(bar2.AsRawString() ==
+@"<bar2 id='2'>
+        <baz>abc</baz>
+    </bar2>");
+
+            var baz = bar2.FindChild("baz");
+            Assert.True(baz.AsRawString() == @"<baz>abc</baz>");
+        }
+    }
+}


### PR DESCRIPTION
# Added method(s)

- in `U8Xml.XmlNode`
  - `public RawString AsRawString()`

# How it works

```cs
const string XmlString =
@"<?xml version='1.0' ?>
<a>
  <b>
    <c>foo</c>
  </b>
</a>";


using XmlObject xml = XmlParser.Parse(XmlString);
XmlNode nodeA = xml.Root;              // <a>...</a>
XmlNode nodeB = nodeA.FindChild("b");  // <b>...</b>

RawString nodeString = nodeB.AsRawString();
Console.WriteLine(nodeString);
```

The output is 

```xml
<b>
    <c>foo</c>
  </b>
```

**NOTE**

The indent of the node is ignored at the head.