### PR TITLE
Fix for parsing attribute contains whitespace.

### DIFF
--- a/src/UnitTest/ParseAttributeTest.cs
+++ b/src/UnitTest/ParseAttributeTest.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+using System;
+using Xunit;
+using U8Xml;
+
+namespace UnitTest
+{
+    public class ParseAttributeTest
+    {
+        [Fact]
+        public void ParseAttribute()
+        {
+            var xmlString =
+@"<root>
+    <n0 abc=""123""/>
+    <n1 abc =""123""/>
+    <n2 abc  =""123""/>
+    <n3 abc= ""123""/>
+    <n4 abc = ""123""/>
+    <n5 abc  = ""123""/>
+    <n6 abc=  ""123""/>
+    <n7 abc =  ""123""/>
+    <n8 abc  =  ""123""/>
+    <n9 abc
+       =""123""/>
+    <n10 abc=
+        ""123""/>
+    <n11 abc 
+       =
+        ""123""/>
+</root>";
+
+            using var xml = XmlParser.Parse(xmlString);
+            var root = xml.Root;
+
+            ReadOnlySpan<byte> name_abc = stackalloc byte[3] { (byte)'a', (byte)'b', (byte)'c' };
+            ReadOnlySpan<byte> value_123 = stackalloc byte[3] { (byte)'1', (byte)'2', (byte)'3' };
+
+            foreach(var n in root.Children) {
+                var (name, value) = n.FindAttribute(name_abc);
+                Assert.True(value == value_123);
+                Assert.True(name == name_abc);
+            }
+        }
+    }
+}

--- a/src/UnitTest/ParseAttributeTest.cs
+++ b/src/UnitTest/ParseAttributeTest.cs
@@ -42,5 +42,29 @@ namespace UnitTest
                 Assert.True(name == name_abc);
             }
         }
+
+        [Fact]
+        public void ParseAttributeFail()
+        {
+            Assert.Throws<FormatException>(() =>
+            {
+                using var xml = XmlParser.Parse(@"<root><foo =""123"" /></root>");
+            });
+
+            Assert.Throws<FormatException>(() =>
+            {
+                using var xml = XmlParser.Parse(@"<root><foo abc=123 /></root>");
+            });
+
+            Assert.Throws<FormatException>(() =>
+            {
+                using var xml = XmlParser.Parse(@"<root><foo abc='123"" /></root>");
+            });
+
+            Assert.Throws<FormatException>(() =>
+            {
+                using var xml = XmlParser.Parse(@"<root><foo abc=""123' /></root>");
+            });
+        }
     }
 }


### PR DESCRIPTION
Allow whitespace before and after the attribute `=`.
Whitespace means `' '`, `'\t'`, `'\n'`, and `'\r'`.

This PR will allow node2, node3, and node4 in the following.

```xml
<root>
  <node1 name="value" />

  <node2 name ="value" />
  <node3 name= "value" />
  <node4 name=
    "value" />
</root>
```

close #17 