### PR TITLE
Fix AsRawString method of a text node

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
@@ -277,7 +277,9 @@ namespace U8Xml
                 byte* nodeStrPtr = data.GetPtr() + nodeStrStart;
                 var node = nodeStack.Peek();
                 var textNode = store.AddTextNode(nodeStack.Count, nodeStrPtr);
-                GetInnerText(data, ref i, out textNode->InnerText);
+                GetInnerText(data, ref i, out var text);
+                textNode->InnerText = text;
+                textNode->NodeStrLength = text.Length;
                 XmlNode_.AddChildTextNode(node, textNode);
                 goto None;
             }

--- a/src/UnitTest/NodeStringTest.cs
+++ b/src/UnitTest/NodeStringTest.cs
@@ -55,5 +55,18 @@ namespace UnitTest
             var baz = bar2.FindChild("baz");
             Assert.True(baz.AsRawString() == @"<baz>abc</baz>");
         }
+
+        [Fact]
+        public void TextNodeAsString()
+        {
+            const string XmlString = @"<root>abc</root>";
+
+            using var xml = XmlParser.Parse(XmlString);
+            var textNode = xml.Root.GetChildren(XmlNodeType.TextNode).First();
+
+            Assert.Equal(XmlNodeType.TextNode, textNode.NodeType);
+            Assert.Equal("abc", textNode.InnerText.ToString());
+            Assert.Equal("abc", textNode.AsRawString().ToString());
+        }
     }
 }


### PR DESCRIPTION
Bug fix for #21 

`XmlNode.AsRawString()` was broken when the node type is `XmlNodeType.TextNode`.