### PR TITLE
Enables parsing of xml ending with a comment.

### DIFF
--- a/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
+++ b/src/U8XmlParserUnity/Assets/Plugins/U8XmlParser/Runtime/XmlParser.cs
@@ -263,7 +263,10 @@ namespace U8Xml
                 // Must be '<', otherwise error.
                 if(data.At(i) == '<') {
                     if(nodeStack.Count == 0 && store.NodeCount > 0) {
-                        throw NewFormatException(data, i, "Xml does not have multiple root nodes.");
+                        var isComment = (i + 3 < data.Length) && (data.At(i + 1) == '!') && (data.At(i + 2) == '-') && (data.At(i + 3) == '-');
+                        if(!isComment) {
+                            throw NewFormatException(data, i, "Xml does not have multiple root nodes.");
+                        }
                     }
                     if(i + 1 < data.Length && data.At(i + 1) == '/') {
                         i += 2;

--- a/src/UnitTest/CommentTest.cs
+++ b/src/UnitTest/CommentTest.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+using Xunit;
+using U8Xml;
+
+namespace UnitTest
+{
+    public class CommentTest
+    {
+        [Fact]
+        public void CommentAtEnd()
+        {
+            using var xml = XmlParser.Parse(
+@"<foo></foo>
+<!-- comment -->");
+            Assert.Equal("foo", xml.Root.Name.ToString());
+        }
+
+        [Fact]
+        public void CommentAtHead()
+        {
+            using var xml = XmlParser.Parse(
+@"<!-- comment -->
+<foo></foo>");
+            Assert.Equal("foo", xml.Root.Name.ToString());
+        }
+
+        [Fact]
+        public void CommentInNode()
+        {
+            using var xml = XmlParser.Parse(
+@"<foo>
+<!-- comment -->
+</foo>");
+            Assert.Equal("foo", xml.Root.Name.ToString());
+        }
+    }
+}


### PR DESCRIPTION
close #32 

Now the parser can parse the following.

```xml
<foo></foo>
<!-- comment -->
```